### PR TITLE
Remove deprecated set-output command

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ runs:
           ${{ runner.os }}-test-${{ inputs.cache-name }}-
 
     - id: hit
-      run: echo "cache-hit$CACHE_HIT" >> $GITHUB_OUTPUT
+      run: echo "cache-hit=$CACHE_HIT" >> $GITHUB_OUTPUT
       env:
         CACHE_HIT: ${{ steps.cache.outputs.cache-hit }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ runs:
           ${{ runner.os }}-test-${{ inputs.cache-name }}-
 
     - id: hit
-      run: echo "::set-output name=cache-hit::$(echo $CACHE_HIT)"
+      run: echo "cache-hit$CACHE_HIT" >> $GITHUB_OUTPUT
       env:
         CACHE_HIT: ${{ steps.cache.outputs.cache-hit }}
       shell: bash


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ & https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter