### PR TITLE
add option to cache custom depot dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ That is why caching the registries is disabled by default.
 - `cache-registries` - Whether to cache `~/.julia/registries/`. Disabled by default.
 - `cache-compiled` - Whether to cache `~/.julia/compiled/`. Disabled by default. **USE ONLY IF YOU KNOW WHAT YOU'RE DOING!** See [#11](https://github.com/julia-actions/cache/issues/11).
 - `cache-scratchspaces` - Whether to cache `~/.julia/scratchspaces/`. Enabled by default.
+- `cache-custom` - Provide a directory name to cache a custom depot directory at `~/.julia/{name}/`. Disabled by default.
 
 ### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,9 @@ inputs:
   cache-scratchspaces:
     description: 'Whether to cache ~/.julia/scratchspaces/'
     default: 'true'
+  cache-custom:
+    description: 'Provide a directory name to cache a custom depot directory at ~/.julia/{name}/'
+    default: ''
 
 outputs:
   cache-hit:
@@ -46,12 +49,14 @@ runs:
         echo "precompilation-cache-path=$PCC_PATH" >> $GITHUB_OUTPUT
         [ "${{ inputs.cache-scratchspaces }}" = "true" ] && S_PATH="~/.julia/scratchspaces"
         echo "scratchspaces-path=$S_PATH" >> $GITHUB_OUTPUT
+        [ "${{ inputs.cache-custom }}" != "" ] && S_PATH="~/.julia/${{ inputs.cache-custom }}"
+        echo "custom-path=$S_PATH" >> $GITHUB_OUTPUT
       shell: bash
 
     - uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
       id: cache
       with:
-        path: "${{ format('{0}\n{1}\n{2}\n{3}\n{4}', steps.paths.outputs.artifacts-path, steps.paths.outputs.packages-path, steps.paths.outputs.registries-path, steps.paths.outputs.precompilation-cache-path, steps.paths.outputs.scratchspaces-path) }}"
+        path: "${{ format('{0}\n{1}\n{2}\n{3}\n{4}\n{5}', steps.paths.outputs.artifacts-path, steps.paths.outputs.packages-path, steps.paths.outputs.registries-path, steps.paths.outputs.precompilation-cache-path, steps.paths.outputs.scratchspaces-path, steps.paths.outputs.custom-path) }}"
         key: ${{ runner.os }}-${{ inputs.cache-name }}-${{ hashFiles('**/Project.toml') }}
         restore-keys: |
           ${{ runner.os }}-${{ inputs.cache-name }}-


### PR DESCRIPTION
Closes https://github.com/julia-actions/cache/issues/72

For now this is just a single directory entry, but if people need it it could be extended by inclusion of a delimiter.