### PR TITLE
Unique cache-key for job matrix objects

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,7 +36,13 @@ jobs:
     needs: generate-key
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        dep:
+          - name: pandoc_jll
+            version: "3"
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macOS-latest
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -53,7 +59,7 @@ jobs:
         @assert !isdir(dir)
     - name: Install a small binary
       shell: 'julia --color=yes {0}'
-      run: 'using Pkg; Pkg.add("pandoc_jll")'
+      run: 'using Pkg; Pkg.add(PackageSpec(name="${{ matrix.dep.name }}", version="${{ matrix.dep.version }}"))'
 
   # Do tests with no matrix also given the matrix is auto-included in cache key
   test-save-nomatrix:
@@ -79,7 +85,13 @@ jobs:
     needs: [generate-key, test-save]
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        dep:
+          - name: pandoc_jll
+            version: "3"
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macOS-latest
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ However note that caching the registries may mean that the registry will not be 
 
 ### Optional Inputs
 
-- `cache-name` - The cache key prefix. Defaults to `julia-cache-${{ github.workflow }}-${{ github.job }}`. The key body automatically includes matrix vars and the OS. Include any other parameters/details in this prefix to ensure one unique cache key per concurrent job type.
+- `cache-name` - The cache key prefix. Defaults to `julia-cache;workflow=${{ github.workflow }};job=${{ github.job }}`. The key body automatically includes the OS and, unless disabled with `include-matrix`, the matrix vars. Include any other parameters/details in this prefix to ensure one unique cache key per concurrent job type.
 - `include-matrix` - Whether to include the matrix values when constructing the cache key. Defaults to `true`.
 - `depot` - Path to a Julia [depot](https://pkgdocs.julialang.org/v1/glossary/) directory where cached data will be saved to and restored from. Defaults to the first depot in [`JULIA_DEPOT_PATH`](https://docs.julialang.org/en/v1/manual/environment-variables/#JULIA_DEPOT_PATH) if specified. Otherwise, defaults to `~/.julia`.
 - `cache-artifacts` - Whether to cache the depot's `artifacts` directory. Defaults to `true`.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: julia-actions/setup-julia@v1
     - uses: julia-actions/cache@v1
     - uses: julia-actions/julia-buildpkg@v1

--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ runs:
     - name: Install jq
       # Skip installation on GitHub-hosted runners:
       # https://github.com/orgs/community/discussions/48359#discussioncomment-5323864
-      if: ${{ !startsWith(runner.name, "GitHub Actions") }}
+      if: ${{ !startsWith(runner.name, 'GitHub Actions') }}
       uses: dcarbone/install-jq-action@v2.1.0
       with:
         force: false  # Skip install when an existing `jq` is present

--- a/action.yml
+++ b/action.yml
@@ -65,6 +65,7 @@ runs:
       # `matrix_key` joins all of matrix keys/values (including nested objects) to ensure that concurrent runs each use a unique cache key.
     - id: keys
       run: |
+        echo "MATRIX_JSON=$MATRIX_JSON"
         if [ "${{ inputs.include-matrix }}" == "true" ]; then
           matrix_key=$(echo "$MATRIX_JSON" | jq 'paths(type != "object") as $p | ($p | join("-")) + "=" + (getpath($p) | tostring)' | jq -rs 'join(";") | ";" + .')
         fi

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ branding:
 inputs:
   cache-name:
     description: >-
-      The cache key prefix. The key body automatically includes the OS and, unless disabled, the matrix vars
+      The cache key prefix. The key body automatically includes the OS and, unless disabled, the matrix vars.
       Include any other parameters/details in this prefix to ensure one unique cache key per concurrent job type.
     default: julia-cache;workflow=${{ github.workflow }};job=${{ github.job }}
   include-matrix:

--- a/action.yml
+++ b/action.yml
@@ -62,18 +62,19 @@ runs:
         echo "logs-path=$L_PATH" >> $GITHUB_OUTPUT
       shell: bash
 
-      # MATRIX_STRING is a join of all matrix variables that helps concurrent runs have a unique cache key.
-      # The underscore at the end of the restore key demarks the end of the restore section. Without this
-      # a runner without a matrix has a restore key that will cause impropper clearing of caches from those
-      # with a matrix.
+      # `matrix_key` joins all of matrix keys/values (including nested objects) to ensure that concurrent runs each use a unique cache key.
     - id: keys
       run: |
-        [ "${{ inputs.include-matrix }}" == "true" ] && MATRIX_STRING="${{ join(matrix.*, '-') }}"
-        [ -n "$MATRIX_STRING" ] && MATRIX_STRING="-${MATRIX_STRING}"
-        RESTORE_KEY="${{ inputs.cache-name }}-${{ runner.os }}${MATRIX_STRING}_"
-        echo "restore-key=${RESTORE_KEY}" >> $GITHUB_OUTPUT
-        echo "key=${RESTORE_KEY}${{ github.run_id }}-${{ github.run_attempt }}" >> $GITHUB_OUTPUT
+        if [ "${{ inputs.include-matrix }}" == "true" ]; then
+          matrix_key=$(echo "$MATRIX_JSON" | jq 'paths(type != "object") as $p | ($p | join("-")) + "=" + (getpath($p) | tostring)' | jq -rs 'join(";") | ";" + .)
+        fi
+        restore_key="${{ inputs.cache-name }};workflow=${{ github.workflow }};job=${{ github.job }};os=${{ runner.os }}${matrix_key};"
+        key="${restore_key}run_id=${{ github.run_id }};run_attempt=${{ github.run_attempt }}"
+        echo "restore-key=${restore_key}" >> $GITHUB_OUTPUT
+        echo "key=${key}" >> $GITHUB_OUTPUT
       shell: bash
+      env:
+        MATRIX_JSON: ${{ toJSON(matrix) }}
 
     - uses: actions/cache@4d4ae6ae148a43d0fd1eda1800170683e9882738
       id: cache

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ branding:
 inputs:
   cache-name:
     description: 'The cache key prefix. Unless disabled the key body automatically includes matrix vars, and the OS. Include any other parameters/details in this prefix to ensure one unique cache key per concurrent job type.'
-    default: 'julia-cache-${{ github.workflow }}-${{ github.job }}'
+    default: 'julia-cache;workflow=${{ github.workflow }};job=${{ github.job }}'
   include-matrix:
     description: 'Whether to include the matrix values when constructing the cache key.'
     default: 'true'
@@ -67,9 +67,9 @@ runs:
       run: |
         echo "MATRIX_JSON=$MATRIX_JSON"
         if [ "${{ inputs.include-matrix }}" == "true" ]; then
-          matrix_key=$(echo "$MATRIX_JSON" | jq 'paths(type != "object") as $p | ($p | join("-")) + "=" + (getpath($p) | tostring)' | jq -rs 'join(";") | ";" + .')
+          matrix_key=$(echo "$MATRIX_JSON" | jq 'paths(type != "object") as $p | ($p | join("-")) + "=" + (getpath($p) | tostring)' | jq -rs 'join(";") | . + ";"')
         fi
-        restore_key="${{ inputs.cache-name }};workflow=${{ github.workflow }};job=${{ github.job }};os=${{ runner.os }}${matrix_key};"
+        restore_key="${{ inputs.cache-name }};os=${{ runner.os }};${matrix_key}"
         key="${restore_key}run_id=${{ github.run_id }};run_attempt=${{ github.run_attempt }}"
         echo "restore-key=${restore_key}" >> $GITHUB_OUTPUT
         echo "key=${key}" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -66,7 +66,7 @@ runs:
     - id: keys
       run: |
         if [ "${{ inputs.include-matrix }}" == "true" ]; then
-          matrix_key=$(echo "$MATRIX_JSON" | jq 'paths(type != "object") as $p | ($p | join("-")) + "=" + (getpath($p) | tostring)' | jq -rs 'join(";") | ";" + .)
+          matrix_key=$(echo "$MATRIX_JSON" | jq 'paths(type != "object") as $p | ($p | join("-")) + "=" + (getpath($p) | tostring)' | jq -rs 'join(";") | ";" + .')
         fi
         restore_key="${{ inputs.cache-name }};workflow=${{ github.workflow }};job=${{ github.job }};os=${{ runner.os }}${matrix_key};"
         key="${restore_key}run_id=${{ github.run_id }};run_attempt=${{ github.run_attempt }}"

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ branding:
 
 inputs:
   cache-name:
-    description: 'The cache key prefix. Unless disabled the key body automatically includes matrix vars, and the OS. Include any other parameters/details in this prefix to ensure one unique cache key per concurrent job type.'
+    description: 'The cache key prefix. The key body automatically includes the OS and, unless disabled, the matrix vars. Include any other parameters/details in this prefix to ensure one unique cache key per concurrent job type.'
     default: 'julia-cache;workflow=${{ github.workflow }};job=${{ github.job }}'
   include-matrix:
     description: 'Whether to include the matrix values when constructing the cache key.'

--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,11 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    - name: Install jq
+      uses: dcarbone/install-jq-action@v2
+      with:
+        force: true
+
     - id: paths
       run: |
         [ "${{ inputs.cache-artifacts }}" = "true" ] && A_PATH="~/.julia/artifacts"

--- a/action.yml
+++ b/action.yml
@@ -62,11 +62,12 @@ runs:
         echo "logs-path=$L_PATH" >> $GITHUB_OUTPUT
       shell: bash
 
-      # `matrix_key` joins all of matrix keys/values (including nested objects) to ensure that concurrent runs each use a unique cache key.
-    - id: keys
+    - name: Generate Keys
+      id: keys
       run: |
-        echo "MATRIX_JSON=$MATRIX_JSON"
-        if [ "${{ inputs.include-matrix }}" == "true" ]; then
+        # `matrix_key` joins all of matrix keys/values (including nested objects) to ensure that concurrent runs each use a unique cache key.
+        # When `matrix` isn't set for the job then `MATRIX_JSON=null`.
+        if [ "${{ inputs.include-matrix }}" == "true" ] && [ "$MATRIX_JSON" != "null" ]; then
           matrix_key=$(echo "$MATRIX_JSON" | jq 'paths(type != "object") as $p | ($p | join("-")) + "=" + (getpath($p) | tostring)' | jq -rs 'join(";") | . + ";"')
         fi
         restore_key="${{ inputs.cache-name }};os=${{ runner.os }};${matrix_key}"

--- a/action.yml
+++ b/action.yml
@@ -47,9 +47,12 @@ runs:
   using: 'composite'
   steps:
     - name: Install jq
+      # Skip installation on GitHub-hosted runners:
+      # https://github.com/orgs/community/discussions/48359#discussioncomment-5323864
+      if: ${{ startsWith(runner.name, "GitHub Actions") }}
       uses: dcarbone/install-jq-action@v2.1.0
       with:
-        force: true
+        force: false  # Skip install when an existing `jq` is present
 
     - id: paths
       run: |

--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ runs:
     - name: Install jq
       # Skip installation on GitHub-hosted runners:
       # https://github.com/orgs/community/discussions/48359#discussioncomment-5323864
-      if: ${{ startsWith(runner.name, "GitHub Actions") }}
+      if: ${{ !startsWith(runner.name, "GitHub Actions") }}
       uses: dcarbone/install-jq-action@v2.1.0
       with:
         force: false  # Skip install when an existing `jq` is present

--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ runs:
   using: 'composite'
   steps:
     - name: Install jq
-      uses: dcarbone/install-jq-action@v2
+      uses: dcarbone/install-jq-action@v2.1.0
       with:
         force: true
 

--- a/handle_caches.jl
+++ b/handle_caches.jl
@@ -13,7 +13,7 @@ function handle_caches()
         for _ in 1:5 # limit to avoid accidental rate limiting
             hits = split(strip(read(`gh cache list --limit 100 --repo $repo`, String)), keepempty=false)
             search_again = length(hits) == 100
-            filter!(contains(restore_key), hits)
+            filter!(startswith(restore_key), hits)
             isempty(hits) && break
             # We can delete everything that matches the restore key because the new cache is saved later.
             for c in hits


### PR DESCRIPTION
Changes how the default cache key is generated such that YAML objects in the matrix are expanded upon and not just returned as "Object". Due to use combining so many values from the matrix I've also decided to include the key name in the cache key.

The change here should be non-breaking but will result in cache misses when users first update to this version.

Fixes #87.