### PR TITLE
URL encode any invalid key characters

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -91,6 +91,7 @@ jobs:
         dep:
           - name: pandoc_jll
             version: "3"
+            invalid-chars: ","  # Use invalid characters in job matrix to ensure we escape them
         os:
           - ubuntu-latest
           - windows-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,6 +39,7 @@ jobs:
         dep:
           - name: pandoc_jll
             version: "3"
+            invalid-chars: ","  # Use invalid characters in job matrix to ensure we escape them
         os:
           - ubuntu-latest
           - windows-latest

--- a/action.yml
+++ b/action.yml
@@ -95,6 +95,9 @@ runs:
           matrix_key=$(echo "$MATRIX_JSON" | jq 'paths(type != "object") as $p | ($p | join("-")) + "=" + (getpath($p) | tostring)' | jq -rs 'join(";") | . + ";"')
         fi
         restore_key="${{ inputs.cache-name }};os=${{ runner.os }};${matrix_key}"
+        # URL encode any restricted characters:
+        # https://github.com/actions/toolkit/blob/5430c5d84832076372990c7c27f900878ff66dc9/packages/cache/src/cache.ts#L38-L43
+        restore_key=$(sed 's/,/%2C/g' <<<"${restore_key}")
         key="${restore_key}run_id=${{ github.run_id }};run_attempt=${{ github.run_attempt }}"
         echo "restore-key=${restore_key}" >> $GITHUB_OUTPUT
         echo "key=${key}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Noticed in a private workflow that when a matrix values contain commas the cache restore step fails with:
```
Error: Key Validation Error: <redacted-key> cannot contain commas.
```
I ended up [tracking down where the key restrictions are implemented](https://github.com/actions/toolkit/blob/5430c5d84832076372990c7c27f900878ff66dc9/packages/cache/src/cache.ts#L32-L44) and found that there are only two restrictions:
- Limited to a length of 512 characters
- Cannot use commas

I've opted to URL encode the comma character only to keep the artifact key as human-readable as possible while still indicating the presence of a comma. I'm not as worried about the key length limit as my artifact key was only 286 characters and was using a pretty complicated job matrix with included paths.