### PR TITLE
Delete cache entries only on the workflow branch

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -52,7 +52,7 @@ jobs:
       id: cache
       uses: ./
       with:
-        cache-name: ${{ needs.generate-key.outputs.cache-name }}
+        cache-name: ${{ needs.generate-key.outputs.cache-name }}-matrix
         delete-old-caches: required
     - name: Check no artifacts dir
       shell: 'julia --color=yes {0}'
@@ -73,7 +73,7 @@ jobs:
       id: cache
       uses: ./
       with:
-        cache-name: ${{ needs.generate-key.outputs.cache-name }}
+        cache-name: ${{ needs.generate-key.outputs.cache-name }}-nomatrix
         delete-old-caches: required
     - name: Check no artifacts dir
       shell: 'julia --color=yes {0}'
@@ -108,7 +108,7 @@ jobs:
       id: cache
       uses: ./
       with:
-        cache-name: ${{ needs.generate-key.outputs.cache-name }}
+        cache-name: ${{ needs.generate-key.outputs.cache-name }}-matrix
         # Cannot require a successful cache delete on forked PRs as the permissions for actions is limited to read
         delete-old-caches: ${{ github.event.pull_request.head.repo.full_name != 'julia-actions/cache' && 'false' || 'required' }}
     - name: Test cache-hit output
@@ -145,7 +145,7 @@ jobs:
       id: cache
       uses: ./
       with:
-        cache-name: ${{ needs.generate-key.outputs.cache-name }}
+        cache-name: ${{ needs.generate-key.outputs.cache-name }}-nomatrix
         # Cannot require a successful cache delete on forked PRs as the permissions for actions is limited to read
         delete-old-caches: ${{ github.event.pull_request.head.repo.full_name != 'julia-actions/cache' && 'false' || 'required' }}
     - name: Test cache-hit output

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -85,6 +85,9 @@ jobs:
 
   test-restore:
     needs: [generate-key, test-save]
+    permissions:
+      actions: write
+      contents: read
     strategy:
       matrix:
         dep:
@@ -129,6 +132,9 @@ jobs:
 
   test-restore-nomatrix:
     needs: [generate-key, test-save-nomatrix]
+    permissions:
+      actions: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,12 +25,11 @@ jobs:
     outputs:
       cache-name: ${{ steps.name.outputs.cache-name }}
     steps:
-    - name: Generate random file
-      shell: 'julia --color=yes {0}'
-      run: 'write("random.txt", string(rand(10)))'
-    - name: Set cache-name as output
+    - name: Generate random cache-name
       id: name
-      run: echo "cache-name=${{ hashFiles('random.txt') }}" >> $GITHUB_OUTPUT
+      run: |
+        cache_name=$(head -n 100 </dev/urandom | shasum -a 256 | cut -d ' ' -f 1)
+        echo "cache-name=$cache_name" | tee -a "$GITHUB_OUTPUT"
 
   test-save:
     needs: generate-key

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -87,9 +87,6 @@ jobs:
 
   test-restore:
     needs: [generate-key, test-save]
-    permissions:
-      actions: write
-      contents: read
     strategy:
       matrix:
         dep:
@@ -137,9 +134,6 @@ jobs:
 
   test-restore-nomatrix:
     needs: [generate-key, test-save-nomatrix]
-    permissions:
-      actions: write
-      contents: read
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -54,6 +54,7 @@ jobs:
       uses: ./
       with:
         cache-name: ${{ needs.generate-key.outputs.cache-name }}
+        delete-old-caches: required
     - name: Check no artifacts dir
       shell: 'julia --color=yes {0}'
       run: |
@@ -74,6 +75,7 @@ jobs:
       uses: ./
       with:
         cache-name: ${{ needs.generate-key.outputs.cache-name }}
+        delete-old-caches: required
     - name: Check no artifacts dir
       shell: 'julia --color=yes {0}'
       run: |
@@ -108,6 +110,8 @@ jobs:
       uses: ./
       with:
         cache-name: ${{ needs.generate-key.outputs.cache-name }}
+        # Cannot require a successful cache delete on forked PRs as the permissions for actions is limited to read
+        delete-old-caches: ${{ github.event.pull_request.head.repo.full_name != 'julia-actions/cache' && 'false' || 'required' }}
     - name: Test cache-hit output
       shell: 'julia --color=yes {0}'
       run: |
@@ -143,6 +147,8 @@ jobs:
       uses: ./
       with:
         cache-name: ${{ needs.generate-key.outputs.cache-name }}
+        # Cannot require a successful cache delete on forked PRs as the permissions for actions is limited to read
+        delete-old-caches: ${{ github.event.pull_request.head.repo.full_name != 'julia-actions/cache' && 'false' || 'required' }}
     - name: Test cache-hit output
       shell: 'julia --color=yes {0}'
       run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -109,7 +109,7 @@ jobs:
       with:
         cache-name: ${{ needs.generate-key.outputs.cache-name }}-matrix
         # Cannot require a successful cache delete on forked PRs as the permissions for actions is limited to read
-        delete-old-caches: ${{ github.event.pull_request.head.repo.full_name != 'julia-actions/cache' && 'false' || 'required' }}
+        delete-old-caches: ${{ github.event.pull_request.head.repo.fork && 'false' || 'required' }}
     - name: Test cache-hit output
       shell: 'julia --color=yes {0}'
       run: |
@@ -143,7 +143,7 @@ jobs:
       with:
         cache-name: ${{ needs.generate-key.outputs.cache-name }}-nomatrix
         # Cannot require a successful cache delete on forked PRs as the permissions for actions is limited to read
-        delete-old-caches: ${{ github.event.pull_request.head.repo.full_name != 'julia-actions/cache' && 'false' || 'required' }}
+        delete-old-caches: ${{ github.event.pull_request.head.repo.fork && 'false' || 'required' }}
     - name: Test cache-hit output
       shell: 'julia --color=yes {0}'
       run: |

--- a/action.yml
+++ b/action.yml
@@ -127,21 +127,21 @@ runs:
 
     # Not windows
     - uses: pyTooling/Actions/with-post-step@adef08d3bdef092282614f3b683897cefae82ee3
-      if: ${{ inputs.delete-old-caches == 'true' && runner.OS != 'Windows' }}
+      if: ${{ inputs.delete-old-caches != 'false' && runner.OS != 'Windows' }}
       with:
         # seems like there has to be a `main` step in this action. Could list caches for info if we wanted
         # main:  julia ${{ github.action_path }}/handle_caches.jl "${{ github.repository }}" "list"
         main: echo ""
-        post: julia $GITHUB_ACTION_PATH/handle_caches.jl rm "${{ github.repository }}" "${{ steps.keys.outputs.restore-key }}" "${{ github.ref }}"
+        post: julia $GITHUB_ACTION_PATH/handle_caches.jl rm "${{ github.repository }}" "${{ steps.keys.outputs.restore-key }}" "${{ github.ref }}" "${{ inputs.delete-old-caches != 'required' }}"
       env:
         GH_TOKEN: ${{ inputs.token }}
 
     # Windows (because this action uses command prompt on windows)
     - uses: pyTooling/Actions/with-post-step@adef08d3bdef092282614f3b683897cefae82ee3
-      if: ${{ inputs.delete-old-caches == 'true' && runner.OS == 'Windows' }}
+      if: ${{ inputs.delete-old-caches != 'false' && runner.OS == 'Windows' }}
       with:
         main: echo ""
-        post: cd %GITHUB_ACTION_PATH% && julia handle_caches.jl rm "${{ github.repository }}" "${{ steps.keys.outputs.restore-key }}" "${{ github.ref }}"
+        post: cd %GITHUB_ACTION_PATH% && julia handle_caches.jl rm "${{ github.repository }}" "${{ steps.keys.outputs.restore-key }}" "${{ github.ref }}" "${{ inputs.delete-old-caches != 'required' }}"
       env:
         GH_TOKEN: ${{ inputs.token }}
 

--- a/action.yml
+++ b/action.yml
@@ -132,7 +132,7 @@ runs:
         # seems like there has to be a `main` step in this action. Could list caches for info if we wanted
         # main:  julia ${{ github.action_path }}/handle_caches.jl "${{ github.repository }}" "list"
         main: echo ""
-        post: julia $GITHUB_ACTION_PATH/handle_caches.jl "${{ github.repository }}" "rm" "${{ steps.keys.outputs.restore-key }}"
+        post: julia $GITHUB_ACTION_PATH/handle_caches.jl rm "${{ github.repository }}" "${{ steps.keys.outputs.restore-key }}" "${{ github.ref }}"
       env:
         GH_TOKEN: ${{ inputs.token }}
 
@@ -141,7 +141,7 @@ runs:
       if: ${{ inputs.delete-old-caches == 'true' && runner.OS == 'Windows' }}
       with:
         main: echo ""
-        post: cd %GITHUB_ACTION_PATH% && julia handle_caches.jl "${{ github.repository }}" "rm" "${{ steps.keys.outputs.restore-key }}"
+        post: cd %GITHUB_ACTION_PATH% && julia handle_caches.jl rm "${{ github.repository }}" "${{ steps.keys.outputs.restore-key }}" "${{ github.ref }}"
       env:
         GH_TOKEN: ${{ inputs.token }}
 

--- a/handle_caches.jl
+++ b/handle_caches.jl
@@ -3,11 +3,12 @@ function handle_caches()
     subcommand = ARGS[1]
 
     if subcommand == "list"
-        repo, = ARGS[2:end]
+        repo = ARGS[2]
         println("Listing existing caches")
         run(`gh cache list --limit 100 --repo $repo`)
     elseif subcommand == "rm"
-        repo, restore_key, ref = ARGS[2:end]
+        repo, restore_key, ref = ARGS[2:4]
+        allow_failure = ARGS[5] == "true"
 
         endpoint = "/repos/$repo/actions/caches"
         page = 1
@@ -52,6 +53,7 @@ function handle_caches()
                     Or provide a token with `repo` scope via the `token` input option.
                     See https://cli.github.com/manual/gh_cache_delete
                     """
+                allow_failure || exit(1)
             end
             if !isempty(deletions)
                 println("Deleted $(length(deletions)) caches on ref `$ref` matching restore key `$restore_key`")

--- a/handle_caches.jl
+++ b/handle_caches.jl
@@ -43,11 +43,11 @@ function handle_caches()
                 println.(failures)
                 @info """
                     To delete caches you need to grant the following to the default `GITHUB_TOKEN` by adding
-                    this to your yml:
+                    this to your workflow:
                     ```
                     permissions:
-                        actions: write
-                        contents: read
+                      actions: write
+                      contents: read
                     ```
                     (Note this won't work for fork PRs but should once merged)
                     Or provide a token with `repo` scope via the `token` input option.


### PR DESCRIPTION
I've noticed that the post-action step which automatically cleans up old cache entries accidentally cleans up entries created on other branches. This reduces performance with multiple PRs are being developed concurrently especially in the scenario where a PR deletes the cache entry for the main branch resulting in all new PRs having cache misses until a PR has been merged.

This PR updates the handle_caches.jl script to only delete caches which match the restore key using the same git ref as the executing workflow. This should result in workflows run on the main branch only deleting cache entries on main and PRs only deleting cache entries for that PR.

For more details about cache isolation in regards to branches see: https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache
