### PR TITLE
Avoid corrupting existing cloned Julia registries

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -167,7 +167,7 @@ jobs:
         @assert !isempty(readdir(logs_dir))
 
   test-save-cloned-registry:
-    needs: [generate-key, test-save-cloned-registry]
+    needs: [generate-key]
     runs-on: ubuntu-latest
     outputs:
       cache-name: ${{ steps.cache-name.outputs.cache-name }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -166,3 +166,54 @@ jobs:
         logs_dir = joinpath(first(DEPOT_PATH), "logs")
         @assert !isempty(readdir(logs_dir))
 
+  test-save-cloned-registry:
+    needs: [generate-key, test-save-cloned-registry]
+    runs-on: ubuntu-latest
+    outputs:
+      cache-name: ${{ steps.cache-name.outputs.cache-name }}
+    steps:
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+    - name: Set cache-name
+      id: cache-name
+      run: |
+        echo "cache-name=${{ needs.generate-key.outputs.cache-name }}-${{ github.job }}" >>"$GITHUB_OUTPUT"
+    - name: Save cache
+      uses: ./
+      with:
+        cache-name: ${{ steps.cache-name.outputs.cache-name }}
+        # Cannot require a successful cache delete on forked PRs as the permissions for actions is limited to read
+        delete-old-caches: ${{ github.event.pull_request.head.repo.fork && 'false' || 'required' }}
+    - name: Add General registry clone
+      shell: julia --color=yes {0}
+      run: |
+        using Pkg
+        Pkg.Registry.add("General")
+      env:
+        JULIA_PKG_SERVER: ""
+    # Set the registry worktree to an older state to simulate the cache storing an old version of the registry.
+    - name: Use outdated General worktree
+      run: git -C ~/.julia/registries/General reset --hard HEAD~20
+
+  test-restore-cloned-registry:
+    needs: [test-save-cloned-registry]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+    - name: Add General registry clone
+      shell: julia --color=yes {0}
+      run: |
+        using Pkg
+        Pkg.Registry.add("General")
+      env:
+        JULIA_PKG_SERVER: ""
+    - name: Restore cache
+      uses: ./
+      with:
+        cache-name: ${{ needs.test-save-cloned-registry.outputs.cache-name }}
+        # Cannot require a successful cache delete on forked PRs as the permissions for actions is limited to read
+        delete-old-caches: ${{ github.event.pull_request.head.repo.fork && 'false' || 'required' }}
+    - name: Test registry is not corrupt
+      shell: julia --color=yes {0}
+      run: |
+        using Pkg
+        Pkg.Registry.update()

--- a/action.yml
+++ b/action.yml
@@ -75,7 +75,13 @@ runs:
         [ "${{ inputs.cache-packages }}" = "true" ] && P_PATH="${depot}/packages"
         echo "packages-path=$P_PATH" >> $GITHUB_OUTPUT
         [ "${{ inputs.cache-registries }}" = "true" ] && R_PATH="${depot}/registries"
-        echo "registries-path=$R_PATH" >> $GITHUB_OUTPUT
+        if [ "${{ inputs.cache-registries }}" = "true" ]; then
+            if [ ! -d "$R_PATH" ]; then
+                echo "registries-path=$R_PATH" >> $GITHUB_OUTPUT
+            else
+                echo "::warning::Julia depot registries already exist. Skipping restoring of cached registries to avoid potential merge conflicts when updating. Please ensure that \`julia-actions/cache\` preceeds any workflow steps which add registries."
+            fi
+        fi
         [ "${{ inputs.cache-compiled }}" = "true" ] && PCC_PATH="${depot}/compiled"
         echo "compiled-path=$PCC_PATH" >> $GITHUB_OUTPUT
         [ "${{ inputs.cache-scratchspaces }}" = "true" ] && S_PATH="${depot}/scratchspaces"

--- a/action.yml
+++ b/action.yml
@@ -69,25 +69,32 @@ runs:
         else
             depot="~/.julia"
         fi
-        echo "depot=$depot" >> $GITHUB_OUTPUT
-        [ "${{ inputs.cache-artifacts }}" = "true" ] && A_PATH="${depot}/artifacts"
-        echo "artifacts-path=$A_PATH" >> $GITHUB_OUTPUT
-        [ "${{ inputs.cache-packages }}" = "true" ] && P_PATH="${depot}/packages"
-        echo "packages-path=$P_PATH" >> $GITHUB_OUTPUT
-        [ "${{ inputs.cache-registries }}" = "true" ] && R_PATH="${depot}/registries"
+        echo "depot=$depot" | tee -a "$GITHUB_OUTPUT"
+
+        cache_paths=()
+        artifacts_path="${depot}/artifacts"
+        [ "${{ inputs.cache-artifacts }}" = "true" ] && cache_paths+=("$artifacts_path")
+        packages_path="${depot}/packages"
+        [ "${{ inputs.cache-packages }}" = "true" ] && cache_paths+=("$packages_path")
+        registries_path="${depot}/registries"
         if [ "${{ inputs.cache-registries }}" = "true" ]; then
-            if [ ! -d "${R_PATH/#\~/$HOME}" ]; then
-                echo "registries-path=$R_PATH" >> $GITHUB_OUTPUT
+            if [ ! -d "${registries_path/#\~/$HOME}" ]; then
+                cache_paths+=("$registries_path")
             else
                 echo "::warning::Julia depot registries already exist. Skipping restoring of cached registries to avoid potential merge conflicts when updating. Please ensure that \`julia-actions/cache\` preceeds any workflow steps which add registries."
             fi
         fi
-        [ "${{ inputs.cache-compiled }}" = "true" ] && PCC_PATH="${depot}/compiled"
-        echo "compiled-path=$PCC_PATH" >> $GITHUB_OUTPUT
-        [ "${{ inputs.cache-scratchspaces }}" = "true" ] && S_PATH="${depot}/scratchspaces"
-        echo "scratchspaces-path=$S_PATH" >> $GITHUB_OUTPUT
-        [ "${{ inputs.cache-logs }}" = "true" ] && L_PATH="${depot}/logs"
-        echo "logs-path=$L_PATH" >> $GITHUB_OUTPUT
+        compiled_path="${depot}/compiled"
+        [ "${{ inputs.cache-compiled }}" = "true" ] && cache_paths+=("$compiled_path")
+        scratchspaces_path="${depot}/scratchspaces"
+        [ "${{ inputs.cache-scratchspaces }}" = "true" ] && cache_paths+=("$scratchspaces_path")
+        logs_path="${depot}/logs"
+        [ "${{ inputs.cache-logs }}" = "true" ] && cache_paths+=("$logs_path")
+        {
+            echo "cache-paths<<EOF"
+            printf "%s\n" "${cache_paths[@]}"
+            echo "EOF"
+        } | tee -a "$GITHUB_OUTPUT"
       shell: bash
       env:
         PATH_DELIMITER: ${{ runner.OS == 'Windows' && ';' || ':' }}
@@ -115,13 +122,7 @@ runs:
       id: cache
       with:
         path: |
-          ${{ steps.paths.outputs.artifacts-path }}
-          ${{ steps.paths.outputs.packages-path }}
-          ${{ steps.paths.outputs.registries-path }}
-          ${{ steps.paths.outputs.scratchspaces-path }}
-          ${{ steps.paths.outputs.compiled-path }}
-          ${{ steps.paths.outputs.logs-path }}
-
+          ${{ steps.paths.outputs.cache-paths }}
         key: ${{ steps.keys.outputs.key }}
         restore-keys: ${{ steps.keys.outputs.restore-key }}
         enableCrossOsArchive: false

--- a/action.yml
+++ b/action.yml
@@ -76,7 +76,7 @@ runs:
         echo "packages-path=$P_PATH" >> $GITHUB_OUTPUT
         [ "${{ inputs.cache-registries }}" = "true" ] && R_PATH="${depot}/registries"
         if [ "${{ inputs.cache-registries }}" = "true" ]; then
-            if [ ! -d "$R_PATH" ]; then
+            if [ ! -d "${R_PATH/#\~/$HOME}" ]; then
                 echo "registries-path=$R_PATH" >> $GITHUB_OUTPUT
             else
                 echo "::warning::Julia depot registries already exist. Skipping restoring of cached registries to avoid potential merge conflicts when updating. Please ensure that \`julia-actions/cache\` preceeds any workflow steps which add registries."


### PR DESCRIPTION
Avoid restoring cached registries when the user already has registries in the Julia depot. If we restore the cached registries for cloned repos we end up putting the registry worktree into a dirty state which will cause failures when attempting to update the registry later.

Fixes #94.