### PR TITLE
Pass cache-name between save/restore jobs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -71,33 +71,6 @@ jobs:
       shell: 'julia --color=yes {0}'
       run: 'using Pkg; Pkg.add(PackageSpec(name="${{ matrix.dep.name }}", version="${{ matrix.dep.version }}"))'
 
-  # Do tests with no matrix also given the matrix is auto-included in cache key
-  test-save-nomatrix:
-    needs: generate-prefix
-    runs-on: ubuntu-latest
-    outputs:
-      cache-name: ${{ steps.cache-name.outputs.cache-name }}
-    steps:
-    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
-    - name: Set cache-name
-      id: cache-name
-      run: |
-        echo "cache-name=${{ needs.generate-prefix.outputs.cache-prefix }}-${{ github.job }}" >>"$GITHUB_OUTPUT"
-    - name: Save cache
-      id: cache
-      uses: ./
-      with:
-        cache-name: ${{ steps.cache-name.outputs.cache-name }}
-        delete-old-caches: required
-    - name: Check no artifacts dir
-      shell: 'julia --color=yes {0}'
-      run: |
-        dir = joinpath(first(DEPOT_PATH), "artifacts")
-        @assert !isdir(dir)
-    - name: Install a small binary
-      shell: 'julia --color=yes {0}'
-      run: 'using Pkg; Pkg.add("pandoc_jll")'
-
   test-restore:
     needs: test-save
     runs-on: ${{ matrix.os }}
@@ -144,6 +117,33 @@ jobs:
         @assert !isempty(readdir(scratchspaces_dir))
         logs_dir = joinpath(first(DEPOT_PATH), "logs")
         @assert !isempty(readdir(logs_dir))
+
+  # Do tests with no matrix also given the matrix is auto-included in cache key
+  test-save-nomatrix:
+    needs: generate-prefix
+    runs-on: ubuntu-latest
+    outputs:
+      cache-name: ${{ steps.cache-name.outputs.cache-name }}
+    steps:
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+    - name: Set cache-name
+      id: cache-name
+      run: |
+        echo "cache-name=${{ needs.generate-prefix.outputs.cache-prefix }}-${{ github.job }}" >>"$GITHUB_OUTPUT"
+    - name: Save cache
+      id: cache
+      uses: ./
+      with:
+        cache-name: ${{ steps.cache-name.outputs.cache-name }}
+        delete-old-caches: required
+    - name: Check no artifacts dir
+      shell: 'julia --color=yes {0}'
+      run: |
+        dir = joinpath(first(DEPOT_PATH), "artifacts")
+        @assert !isdir(dir)
+    - name: Install a small binary
+      shell: 'julia --color=yes {0}'
+      run: 'using Pkg; Pkg.add("pandoc_jll")'
 
   test-restore-nomatrix:
     needs: test-save-nomatrix

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -156,7 +156,7 @@ jobs:
 
   # Do tests with no matrix also given the matrix is auto-included in cache key
   test-save-nomatrix:
-    needs: generate-key
+    needs: generate-prefix
     runs-on: ubuntu-latest
     outputs:
       cache-name: ${{ steps.cache-name.outputs.cache-name }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -55,7 +55,7 @@ jobs:
       id: cache-name
       shell: bash
       run: |
-        echo "cache-name=${{ needs.generate-prefix.outputs.cache-prefix }}-matrix" >>"$GITHUB_OUTPUT"
+        echo "cache-name=${{ needs.generate-prefix.outputs.cache-prefix }}-${{ github.job }}" >>"$GITHUB_OUTPUT"
     - name: Save cache
       id: cache
       uses: ./
@@ -82,7 +82,7 @@ jobs:
     - name: Set cache-name
       id: cache-name
       run: |
-        echo "cache-name=${{ needs.generate-prefix.outputs.cache-prefix }}-nomatrix" >>"$GITHUB_OUTPUT"
+        echo "cache-name=${{ needs.generate-prefix.outputs.cache-prefix }}-${{ github.job }}" >>"$GITHUB_OUTPUT"
     - name: Save cache
       id: cache
       uses: ./

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,19 +20,22 @@ permissions:
   contents: read
 
 jobs:
-  generate-key:
+  generate-prefix:
     runs-on: ubuntu-latest
     outputs:
-      cache-name: ${{ steps.name.outputs.cache-name }}
+      cache-prefix: ${{ steps.name.outputs.cache-prefix }}
     steps:
-    - name: Generate random cache-name
+    - name: Generate random cache-prefix
       id: name
       run: |
-        cache_name=$(head -n 100 </dev/urandom | shasum -a 256 | cut -d ' ' -f 1)
-        echo "cache-name=$cache_name" | tee -a "$GITHUB_OUTPUT"
+        cache_prefix=$(head -n 100 </dev/urandom | shasum -a 256 | cut -d ' ' -f 1)
+        echo "cache-prefix=$cache_prefix" >>"$GITHUB_OUTPUT"
 
   test-save:
-    needs: generate-key
+    needs: generate-prefix
+    runs-on: ${{ matrix.os }}
+    outputs:
+      cache-name: ${{ steps.cache-name.outputs.cache-name }}
     strategy:
       matrix:
         dep:
@@ -44,16 +47,19 @@ jobs:
           - windows-latest
           - macOS-latest
       fail-fast: false
-    runs-on: ${{ matrix.os }}
     env:
       JULIA_DEPOT_PATH: /tmp/julia-depot
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+    - name: Set cache-name
+      id: cache-name
+      run: |
+        echo "cache-name=${{ needs.generate-prefix.outputs.cache-prefix }}-matrix" >>"$GITHUB_OUTPUT"
     - name: Save cache
       id: cache
       uses: ./
       with:
-        cache-name: ${{ needs.generate-key.outputs.cache-name }}-matrix
+        cache-name: ${{ steps.cache-name.outputs.cache-name }}
         delete-old-caches: required
     - name: Check no artifacts dir
       shell: 'julia --color=yes {0}'
@@ -66,15 +72,21 @@ jobs:
 
   # Do tests with no matrix also given the matrix is auto-included in cache key
   test-save-nomatrix:
-    needs: generate-key
+    needs: generate-prefix
     runs-on: ubuntu-latest
+    outputs:
+      cache-name: ${{ steps.cache-name.outputs.cache-name }}
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+    - name: Set cache-name
+      id: cache-name
+      run: |
+        echo "cache-name=${{ needs.generate-prefix.outputs.cache-prefix }}-nomatrix" >>"$GITHUB_OUTPUT"
     - name: Save cache
       id: cache
       uses: ./
       with:
-        cache-name: ${{ needs.generate-key.outputs.cache-name }}-nomatrix
+        cache-name: ${{ steps.cache-name.outputs.cache-name }}
         delete-old-caches: required
     - name: Check no artifacts dir
       shell: 'julia --color=yes {0}'
@@ -86,7 +98,8 @@ jobs:
       run: 'using Pkg; Pkg.add("pandoc_jll")'
 
   test-restore:
-    needs: [generate-key, test-save]
+    needs: test-save
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         dep:
@@ -98,7 +111,6 @@ jobs:
           - windows-latest
           - macOS-latest
       fail-fast: false
-    runs-on: ${{ matrix.os }}
     env:
       JULIA_DEPOT_PATH: /tmp/julia-depot
     steps:
@@ -107,7 +119,7 @@ jobs:
       id: cache
       uses: ./
       with:
-        cache-name: ${{ needs.generate-key.outputs.cache-name }}-matrix
+        cache-name: ${{ needs.test-save.outputs.cache-name }}
         # Cannot require a successful cache delete on forked PRs as the permissions for actions is limited to read
         delete-old-caches: ${{ github.event.pull_request.head.repo.fork && 'false' || 'required' }}
     - name: Test cache-hit output
@@ -133,7 +145,7 @@ jobs:
         @assert !isempty(readdir(logs_dir))
 
   test-restore-nomatrix:
-    needs: [generate-key, test-save-nomatrix]
+    needs: test-save-nomatrix
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
@@ -141,7 +153,7 @@ jobs:
       id: cache
       uses: ./
       with:
-        cache-name: ${{ needs.generate-key.outputs.cache-name }}-nomatrix
+        cache-name: ${{ needs.test-save-nomatrix.outputs.cache-name }}
         # Cannot require a successful cache delete on forked PRs as the permissions for actions is limited to read
         delete-old-caches: ${{ github.event.pull_request.head.repo.fork && 'false' || 'required' }}
     - name: Test cache-hit output
@@ -165,4 +177,3 @@ jobs:
         @assert !isempty(readdir(scratchspaces_dir))
         logs_dir = joinpath(first(DEPOT_PATH), "logs")
         @assert !isempty(readdir(logs_dir))
-

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,6 +53,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
     - name: Set cache-name
       id: cache-name
+      shell: bash
       run: |
         echo "cache-name=${{ needs.generate-prefix.outputs.cache-prefix }}-matrix" >>"$GITHUB_OUTPUT"
     - name: Save cache

--- a/action.yml
+++ b/action.yml
@@ -81,7 +81,7 @@ runs:
             if [ ! -d "${registries_path/#\~/$HOME}" ]; then
                 cache_paths+=("$registries_path")
             else
-                echo "::warning::Julia depot registries already exist. Skipping restoring of cached registries to avoid potential merge conflicts when updating. Please ensure that \`julia-actions/cache\` preceeds any workflow steps which add registries."
+                echo "::warning::Julia depot registries already exist. Skipping restoring of cached registries to avoid potential merge conflicts when updating. Please ensure that \`julia-actions/cache\` precedes any workflow steps which add registries."
             fi
         fi
         compiled_path="${depot}/compiled"


### PR DESCRIPTION
Some CI refactoring after the work in #102 where I found it easier to pass the unique cache name between save and restore instead of reproducing it.