### PR TITLE
fix: Attempt to install jq on all runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ By default all depot directories called out below are cached.
 ### Requirements
 
 This action uses [`jq`](https://github.com/jqlang/jq) to parse JSON.
-`jq` is installed by default in GitHUb-hosted runners.
+`jq` is installed by default in GitHub-hosted runners.
 [`dcarbone/install-jq-action`](https://github.com/dcarbone/install-jq-action) is used to check that `jq` is available and install it if not.
 **Note:** installing `jq` with `dcarbone/install-jq-action` requires that curl is available; this may not be the case in custom containers.
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ jobs:
 
 By default all depot directories called out below are cached.
 
+### Requirements
+
+This action uses [`jq`](https://github.com/jqlang/jq) to parse JSON.
+`jq` is installed by default in GitHUb-hosted runners.
+[`dcarbone/install-jq-action`](https://github.com/dcarbone/install-jq-action) is used to check that `jq` is available and install it if not.
+**Note:** installing `jq` with `dcarbone/install-jq-action` requires that curl is available; this may not be the case in custom containers.
+
 ### Optional Inputs
 
 - `cache-name` - The cache key prefix. Defaults to `julia-cache;workflow=${{ github.workflow }};job=${{ github.job }}`. The key body automatically includes the OS and, unless disabled with `include-matrix`, the matrix vars. Include any other parameters/details in this prefix to ensure one unique cache key per concurrent job type.

--- a/action.yml
+++ b/action.yml
@@ -52,9 +52,9 @@ runs:
   using: 'composite'
   steps:
     - name: Install jq
-      # Skip installation on GitHub-hosted runners:
-      # https://github.com/orgs/community/discussions/48359#discussioncomment-5323864
-      if: ${{ !startsWith(runner.name, 'GitHub Actions') }}
+      # # Skip installation on GitHub-hosted runners:
+      # # https://github.com/orgs/community/discussions/48359#discussioncomment-5323864
+      # if: ${{ !startsWith(runner.name, 'GitHub Actions') }}
       uses: dcarbone/install-jq-action@v2.1.0
       with:
         force: false  # Skip install when an existing `jq` is present

--- a/action.yml
+++ b/action.yml
@@ -52,9 +52,6 @@ runs:
   using: 'composite'
   steps:
     - name: Install jq
-      # # Skip installation on GitHub-hosted runners:
-      # # https://github.com/orgs/community/discussions/48359#discussioncomment-5323864
-      # if: ${{ !startsWith(runner.name, 'GitHub Actions') }}
       uses: dcarbone/install-jq-action@v2.1.0
       with:
         force: false  # Skip install when an existing `jq` is present


### PR DESCRIPTION
Fixes: https://github.com/julia-actions/cache/issues/104

I took the simplest approach, of just removing the check on whether the runner is hosted by GitHub.  This seems to work for both [non-container](https://github.com/musoke/UltraDark.jl/actions/runs/7547005193/job/20546021767#step:4:1) and [container](https://github.com/musoke/WolframExpr.jl/actions/runs/7546831404/job/20545463332#step:6:34) jobs.

There may be other cases and subtleties that I am missing.

The one caveat is that the container has to have curl installed; this was easy to do but may be worth adding to the readme.