### PR TITLE
Pin third party action to hash

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -52,7 +52,7 @@ runs:
   using: 'composite'
   steps:
     - name: Install jq
-      uses: dcarbone/install-jq-action@v2.1.0
+      uses: dcarbone/install-jq-action@8867ddb4788346d7c22b72ea2e2ffe4d514c7bcb
       with:
         force: false  # Skip install when an existing `jq` is present
 


### PR DESCRIPTION
Third party actions should never not be pinned to a hash. Otherwise, in case the action repo is taken over by a malicious actor, they can change what runs in all of the workflows that julia-actions/cache is used in as well. Pinning to a hash prevents that.