### PR TITLE
Mention why the extra permissions are required

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ This cached file is then restored upon the second run, and afterwards resaved un
 The benefit of caching is that downloading one big file is quicker than downloading many different files from many different locations
 and precompiling them.
 
-By default, this actions removes the previous cache to make the cached files are as useful as possible.
-A reason for this is that, unlike many other languages, updating one dependency in Julia can outdate large amounts of precompiled code.
-By removing the old cache, this Action ensures that caches will be updated for small changes to the dependencies.
+By default, this action removes caches that were previously made by jobs on the same branch with the same restore key.
+GitHub automatically removes old caches after a certain period or when the repository cache allocation is full.
+It is, however, more efficient to explicitly remove old caches to improve caching for less frequently run jobs.
 
 ### Cache keys
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ This cached file is then restored upon the second run, and afterwards resaved un
 The benefit of caching is that downloading one big file is quicker than downloading many different files from many different locations
 and precompiling them.
 
+By default, this actions removes the previous cache to make the cached files are as useful as possible.
+A reason for this is that, unlike many other languages, updating one dependency in Julia can outdate large amounts of precompiled code.
+By removing the old cache, this Action ensures that caches will be updated for small changes to the dependencies.
+
 ### Cache keys
 
 The cache key that the cache will be saved as is based on:


### PR DESCRIPTION
The new permissions
```yml
permissions:
  actions: write
  contents: read
```
can be a bit of a hassle to setup for many repositories.

It's probably good to clarify why these permissions are useful in order to avoid confusion and possibly frustration.