### PR TITLE
Update actions/cache to v4.0.2

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -115,7 +115,7 @@ runs:
       env:
         MATRIX_JSON: ${{ toJSON(matrix) }}
 
-    - uses: actions/cache@4d4ae6ae148a43d0fd1eda1800170683e9882738
+    - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
       id: cache
       with:
         path: |


### PR DESCRIPTION
Fixes #119 

As pointed out in https://github.com/julia-actions/cache/issues/119 this was erroneously left in #71 on a commit that had dependencies updated that didn't correspond with a `actions/cache` release.