### PR TITLE
Update actions/cache to v3.3.3

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -115,7 +115,7 @@ runs:
       env:
         MATRIX_JSON: ${{ toJSON(matrix) }}
 
-    - uses: actions/cache@4d4ae6ae148a43d0fd1eda1800170683e9882738
+    - uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.3
       id: cache
       with:
         path: |


### PR DESCRIPTION
Ideally we can merge this as a patch release before https://github.com/julia-actions/cache/pull/120

Fixes #119 

As pointed out in https://github.com/julia-actions/cache/issues/119 this was erroneously left in #71 on a commit that had dependencies updated that didn't correspond with a `actions/cache` release.