### PR TITLE
Fix typo in `cache-name` note

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ The cache key that the cache will be saved as is based on:
 - The run attempt number
 
 > [!NOTE]
-> If in your workflow if you do not use a matrix for concurrency you should make `cache-name` such that it is unique for
-> concurrent jobs, otherwise caching may not be effective.
+> If your workflow uses a matrix for concurrency you should ensure `cache-name` is unique for concurrent jobs or caching may not
+> be effective.
 
 ### Cache Retention
 

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ The cache key that the cache will be saved as is based on:
 - The run attempt number
 
 > [!NOTE]
-> If there are workflows running concurrently without a `matrix`, then ensure `cache-name` to be unique for each job, otherwise
-> caching may not be effective.
+> If there is job concurrency that is not fully defined by a matrix you should ensure that `cache-name` is 
+> unique for each concurrent job, otherwise caching may not be effective.
 
 ### Cache Retention
 

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ The cache key that the cache will be saved as is based on:
 - The run attempt number
 
 > [!NOTE]
-> If your workflow uses a matrix for concurrency you should ensure `cache-name` is unique for concurrent jobs or caching may not
-> be effective.
+> If there are workflows running concurrently without a `matrix`, then ensure `cache-name` to be unique for each job, otherwise
+> caching may not be effective.
 
 ### Cache Retention
 


### PR DESCRIPTION
The old text contained a typo it seems because it said: "if you do not use a matrix for concurrency you could make `cache-name` such that it is unique".