### PR TITLE
README: document that Bash is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ By default all depot directories called out below are cached.
 
 ### Requirements
 
-This action uses [`jq`](https://github.com/jqlang/jq) to parse JSON.
-`jq` is installed by default in GitHub-hosted runners.
-[`dcarbone/install-jq-action`](https://github.com/dcarbone/install-jq-action) is used to check that `jq` is available and install it if not.
-**Note:** installing `jq` with `dcarbone/install-jq-action` requires that curl is available; this may not be the case in custom containers.
+1. `jq`
+    - This action uses [`jq`](https://github.com/jqlang/jq) to parse JSON. `jq` is installed by default in GitHub-hosted runners. [`dcarbone/install-jq-action`](https://github.com/dcarbone/install-jq-action) is used to check that `jq` is available and install it if not. **Note:** installing `jq` with `dcarbone/install-jq-action` requires that `curl` is available; this may not be the case in custom containers.
+2. Bash
+    - This action requires Bash. Bash is installed by default in GitHub-hosted runners. On self-hosted runners, you may need to make sure that Bash is available in the PATH.
 
 ### Optional Inputs
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ By default all depot directories called out below are cached.
 
 ### Requirements
 
-1. `jq`: This action uses [`jq`](https://github.com/jqlang/jq) to parse JSON. For GitHub-hosted runners, `jq` is installed by default. On self-hosted runners and custom containers, if `jq` is not already available, this action will automatically use [`dcarbone/install-jq-action`](https://github.com/dcarbone/install-jq-action) to install `jq` (Note: `dcarbone/install-jq-action` requires that `curl` is installed; this may not always be the case in custom containers and self-hosted runners).
-2. `bash`: This action requires `bash`. For GitHub-hosted runners `bash` is installed by default. Self-hosted runners will need to ensure that `bash` is installed and available on the `PATH`.
+- `jq`: This action uses [`jq`](https://github.com/jqlang/jq) to parse JSON. For GitHub-hosted runners, `jq` is installed by default. On self-hosted runners and custom containers, if `jq` is not already available, this action will automatically use [`dcarbone/install-jq-action`](https://github.com/dcarbone/install-jq-action) to install `jq` (Note: `dcarbone/install-jq-action` requires that `curl` is installed; this may not always be the case in custom containers and self-hosted runners).
+- `bash`: This action requires `bash`. For GitHub-hosted runners `bash` is installed by default. Self-hosted runners will need to ensure that `bash` is installed and available on the `PATH`.
 
 ### Optional Inputs
 

--- a/README.md
+++ b/README.md
@@ -31,10 +31,8 @@ By default all depot directories called out below are cached.
 
 ### Requirements
 
-1. `jq`
-    - This action uses [`jq`](https://github.com/jqlang/jq) to parse JSON. `jq` is installed by default in GitHub-hosted runners. [`dcarbone/install-jq-action`](https://github.com/dcarbone/install-jq-action) is used to check that `jq` is available and install it if not. **Note:** installing `jq` with `dcarbone/install-jq-action` requires that `curl` is available; this may not be the case in custom containers.
-2. Bash
-    - This action requires Bash. Bash is installed by default in GitHub-hosted runners. On self-hosted runners, you may need to make sure that Bash is available in the PATH.
+1. `jq`: This action uses [`jq`](https://github.com/jqlang/jq) to parse JSON. For GitHub-hosted runners `jq` is installed by default. Self-hosted runners can use [`dcarbone/install-jq-action`](https://github.com/dcarbone/install-jq-action) to install `jq` (Note: `dcarbone/install-jq-action` requires that `curl` is installed; this may not be the case in custom containers).
+2. `bash`: This action requires `bash`. For GitHub-hosted runners `bash` is installed by default. Self-hosted runners will need to ensure that `bash` is installed and available on the `PATH`.
 
 ### Optional Inputs
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ By default all depot directories called out below are cached.
 
 ### Requirements
 
-1. `jq`: This action uses [`jq`](https://github.com/jqlang/jq) to parse JSON. For GitHub-hosted runners `jq` is installed by default. Self-hosted runners can use [`dcarbone/install-jq-action`](https://github.com/dcarbone/install-jq-action) to install `jq` (Note: `dcarbone/install-jq-action` requires that `curl` is installed; this may not be the case in custom containers).
+1. `jq`: This action uses [`jq`](https://github.com/jqlang/jq) to parse JSON. For GitHub-hosted runners, `jq` is installed by default. On self-hosted runners and custom containers, if `jq` is not already available, this action will automatically use [`dcarbone/install-jq-action`](https://github.com/dcarbone/install-jq-action) to install `jq` (Note: `dcarbone/install-jq-action` requires that `curl` is installed; this may not always be the case in custom containers and self-hosted runners).
 2. `bash`: This action requires `bash`. For GitHub-hosted runners `bash` is installed by default. Self-hosted runners will need to ensure that `bash` is installed and available on the `PATH`.
 
 ### Optional Inputs


### PR DESCRIPTION
Bash might not be available by default in e.g. self-hosted Windows runners. So we should document this requirement.