### PR TITLE
Fix issues with custom cache eviction

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -148,13 +148,6 @@ runs:
     # - https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
     # - https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy
 
-    - name: Debug
-      shell: bash
-      run: |
-        echo "- ${{ github.event.repository.default_branch }}"
-        echo "- ${{ github.ref }}"
-
-
     # Not windows
     - uses: pyTooling/Actions/with-post-step@e9d0dc3dba9fda45f195946858708f60c0240caf # v1.0.5
       if: ${{ inputs.delete-old-caches != 'false' &&

--- a/action.yml
+++ b/action.yml
@@ -149,6 +149,7 @@ runs:
     # - https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy
 
     - name: Debug
+      shell: bash
       run: |
         echo "- ${{ github.event.repository.default_branch }}"
         echo "- ${{ github.ref }}"

--- a/action.yml
+++ b/action.yml
@@ -133,10 +133,10 @@ runs:
       shell: bash
 
     # GitHub actions cache entries are immutable and cannot be updated. In order to have both the Julia
-    # depot cache be up-to-date and avoid storing redundant cache entries we'll manually cleanup old cache entries before
-    # the new cache is saved. However, we need to be careful with our manual cleanup as otherwise we can
-    # cause cache misses for jobs which would have normally had a cache hit. Some scenarios to keep in
-    # mind include:
+    # depot cache be up-to-date and avoid storing redundant cache entries we'll manually cleanup old
+    # cache entries before the new cache is saved. However, we need to be careful with our manual
+    # cleanup as otherwise we can cause cache misses for jobs which would have normally had a cache hit.
+    # Some scenarios to keep in mind include:
     #
     # - Job failures result in the post-action for `actions/cache` being skipped. If we delete all cache
     #   entries for the branch we may have no cache entry available for the next run.

--- a/action.yml
+++ b/action.yml
@@ -132,12 +132,27 @@ runs:
         du -shc ${{ steps.paths.outputs.depot }}/* || true
       shell: bash
 
-    # github and actions/cache doesn't provide a way to update a cache at a given key, so we delete any
-    # that match the restore key just before saving the new cache
+    # GitHub actions cache entries are immutable and cannot be updated. In order to have both the Julia
+    # depot cache be up-to-date and avoid storing redundant cache entries we'll manually cleanup old cache entries before
+    # the new cache is saved. However, we need to be careful with our manual cleanup as otherwise we can
+    # cause cache misses for jobs which would have normally had a cache hit. Some scenarios to keep in
+    # mind include:
+    #
+    # - Job failures result in the post-action for `actions/cache` being skipped. If we delete all cache
+    #   entries for the branch we may have no cache entry available for the next run.
+    # - We should avoid deleting old cache entries for the default branch since these entries serve as
+    #   the fallback if no earlier cache entry exists on a branch. We can rely on GitHub's default cache
+    #   eviction policy here which will remove the oldest cache entry first.
+    #
+    # References:
+    # - https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
+    # - https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy
 
     # Not windows
     - uses: pyTooling/Actions/with-post-step@e9d0dc3dba9fda45f195946858708f60c0240caf # v1.0.5
-      if: ${{ inputs.delete-old-caches != 'false' && runner.OS != 'Windows' }}
+      if: ${{ inputs.delete-old-caches != 'false' &&
+              github.ref != format('refs/heads/{0}', github.event.repository.default_branch) &&
+              runner.OS != 'Windows' }}
       with:
         # seems like there has to be a `main` step in this action. Could list caches for info if we wanted
         # main:  julia ${{ github.action_path }}/handle_caches.jl "${{ github.repository }}" "list"
@@ -148,7 +163,9 @@ runs:
 
     # Windows (because this action uses command prompt on windows)
     - uses: pyTooling/Actions/with-post-step@e9d0dc3dba9fda45f195946858708f60c0240caf # v1.0.5
-      if: ${{ inputs.delete-old-caches != 'false' && runner.OS == 'Windows' }}
+      if: ${{ inputs.delete-old-caches != 'false' &&
+              github.ref != format('refs/heads/{0}', github.event.repository.default_branch) &&
+              runner.OS == 'Windows' }}
       with:
         main: echo ""
         post: cd %GITHUB_ACTION_PATH% && julia handle_caches.jl rm "${{ github.repository }}" "${{ steps.keys.outputs.restore-key }}" "${{ github.ref }}" "${{ inputs.delete-old-caches != 'required' }}"

--- a/action.yml
+++ b/action.yml
@@ -148,6 +148,12 @@ runs:
     # - https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
     # - https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy
 
+    - name: Debug
+      run: |
+        echo "- ${{ github.event.repository.default_branch }}"
+        echo "- ${{ github.ref }}"
+
+
     # Not windows
     - uses: pyTooling/Actions/with-post-step@e9d0dc3dba9fda45f195946858708f60c0240caf # v1.0.5
       if: ${{ inputs.delete-old-caches != 'false' &&

--- a/handle_caches.jl
+++ b/handle_caches.jl
@@ -19,7 +19,7 @@ function handle_caches()
             # https://docs.github.com/en/rest/actions/cache?apiVersion=2022-11-28#list-github-actions-caches-for-a-repository
             # Note: The `key` field matches on the full key or a prefix.
             cmd = ```
-                gh api -X GET /repos/$repo/actions/cache
+                gh api -X GET /repos/$repo/actions/caches
                     --field per_page=$per_page
                     --field page=$page
                     --field ref=$ref

--- a/handle_caches.jl
+++ b/handle_caches.jl
@@ -32,7 +32,7 @@ function handle_caches()
 
             # Avoid deleting the latest used cache entry. This is particularly important for
             # job failures where a new cache entry will not be saved after this.
-            page == 1 && push!(skipped, popfirst!(ids))
+            page == 1 && !isempty(ids) && push!(skipped, popfirst!(ids))
 
             for id in ids
                 try

--- a/handle_caches.jl
+++ b/handle_caches.jl
@@ -12,8 +12,9 @@ function handle_caches()
 
         page = 1
         per_page = 100
-        deletions = String[]
-        failures = String[]
+        skipped = String[]
+        deleted = String[]
+        failed = String[]
         while 1 <= page <= 5 # limit to avoid accidental rate limiting
             # https://docs.github.com/en/rest/actions/cache?apiVersion=2022-11-28#list-github-actions-caches-for-a-repository
             # Note: The `key` field matches on the full key or a prefix.
@@ -31,26 +32,26 @@ function handle_caches()
 
             # Avoid deleting the latest used cache entry. This is particularly important for
             # job failures where a new cache entry will not be saved after this.
-            page == 1 && popfirst!(ids)
+            page == 1 && push!(skipped, popfirst!(ids))
 
             for id in ids
                 try
                     run(`gh cache delete $id --repo $repo`)
-                    push!(deletions, id)
+                    push!(deleted, id)
                 catch e
                     @error e
-                    push!(failures, id)
+                    push!(failed, id)
                 end
             end
 
             page = length(ids) == per_page ? page + 1 : -1
         end
-        if isempty(failures) && isempty(deletions)
+        if isempty(skipped) && isempty(deleted) && isempty(failed)
             println("No existing caches found on ref `$ref` matching restore key `$restore_key`")
         else
-            if !isempty(failures)
-                println("Failed to delete $(length(failures)) existing caches on ref `$ref` matching restore key `$restore_key`")
-                println.(failures)
+            if !isempty(failed)
+                println("Failed to delete $(length(failed)) existing caches on ref `$ref` matching restore key `$restore_key`")
+                println.(failed)
                 @info """
                     To delete caches you need to grant the following to the default `GITHUB_TOKEN` by adding
                     this to your workflow:
@@ -65,9 +66,9 @@ function handle_caches()
                     """
                 allow_failure || exit(1)
             end
-            if !isempty(deletions)
-                println("Deleted $(length(deletions)) caches on ref `$ref` matching restore key `$restore_key`")
-                println.(deletions)
+            if !isempty(deleted)
+                println("Deleted $(length(deleted)) caches on ref `$ref` matching restore key `$restore_key`")
+                println.(deleted)
             end
         end
     else

--- a/handle_caches.jl
+++ b/handle_caches.jl
@@ -10,21 +10,29 @@ function handle_caches()
         repo, restore_key, ref = ARGS[2:4]
         allow_failure = ARGS[5] == "true"
 
-        endpoint = "/repos/$repo/actions/caches"
         page = 1
         per_page = 100
-        escaped_restore_key = replace(restore_key, "\"" => "\\\"")
-        query = ".actions_caches[] | select(.key | startswith(\"$escaped_restore_key\")) | .id"
-
         deletions = String[]
         failures = String[]
         while 1 <= page <= 5 # limit to avoid accidental rate limiting
-            cmd = `gh api -X GET $endpoint -F ref=$ref -F per_page=$per_page -F page=$page --jq $query`
+            # https://docs.github.com/en/rest/actions/cache?apiVersion=2022-11-28#list-github-actions-caches-for-a-repository
+            # Note: The `key` field matches on the full key or a prefix.
+            cmd = ```
+                gh api -X GET /repos/$repo/actions/cache
+                    --field per_page=$per_page
+                    --field page=$page
+                    --field ref=$ref
+                    --field key=$restore_key
+                    --field sort=last_accessed_at
+                    --field direction=desc
+                    --jq '.actions_caches[].id'
+                ```
             ids = split(read(cmd, String); keepempty=false)
-            page = length(ids) == per_page ? page + 1 : -1
 
-            # We can delete all cache entries on this branch that matches the restore key
-            # because the new cache is saved later.
+            # Avoid deleting the latest used cache entry. This is particularly important for
+            # job failures where a new cache entry will not be saved after this.
+            page == 1 && popfirst!(ids)
+
             for id in ids
                 try
                     run(`gh cache delete $id --repo $repo`)
@@ -34,6 +42,8 @@ function handle_caches()
                     push!(failures, id)
                 end
             end
+
+            page = length(ids) == per_page ? page + 1 : -1
         end
         if isempty(failures) && isempty(deletions)
             println("No existing caches found on ref `$ref` matching restore key `$restore_key`")


### PR DESCRIPTION
Fixes https://github.com/julia-actions/cache/issues/113

In https://github.com/julia-actions/cache/pull/71 when we introduced saving cache entries for each matrix job we also introduced a manual cache eviction step to attempt to evict unnecessary cache entries in a better way than the default GitHub behavior (evict the oldest). Unfortunately, we have ended up being a little overly aggressive in our cache eviction policy which has resulted in the following problems:

1. We assume that a cache entry will be saved upon every job run so it is safe to evict all cache entries on that branch before we save the new entry. For failed jobs no new cache entry is saved so we end up starting from scratch on subsequent runs. In this PR I've updated the behavior to always keep the latest cache entry (possibly in addition to the new cache entry) so failures like this can use the last saved entry.
2. We perform cache eviction on entries from the default branch. As GitHub action caches can only be pulled from the current branch or the base branch the default branch can be rather important for falling back on for a base cache entry. When new commits are added to the default branch the old cache entries are evicted which can leave PRs with no base cache to fall back on. I now avoid performing manual cache eviction on the default branch to avoid this kind of problem.