### PR TITLE
Expand paths which use tilde

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -66,6 +66,7 @@ runs:
         else
             depot="~/.julia"
         fi
+        depot="${depot/#\~/$HOME}"  # Expand tilde which cannot be used in BASH checks (i.e. `[ -d "~/.julia" ]` fails)
         echo "depot=$depot" | tee -a "$GITHUB_OUTPUT"
 
         cache_paths=()
@@ -75,7 +76,7 @@ runs:
         [ "${{ inputs.cache-packages }}" = "true" ] && cache_paths+=("$packages_path")
         registries_path="${depot}/registries"
         if [ "${{ inputs.cache-registries }}" = "true" ]; then
-            if [ ! -d "${registries_path/#\~/$HOME}" ]; then
+            if [ ! -d "${registries_path}" ]; then
                 cache_paths+=("$registries_path")
             else
                 echo "::warning::Julia depot registries already exist. Skipping restoring of cached registries to avoid potential merge conflicts when updating. Please ensure that \`julia-actions/cache\` precedes any workflow steps which add registries."


### PR DESCRIPTION
I noticed a bug with https://github.com/julia-actions/cache/pull/140 where the registry failed to be updated:
```
...
626M    /home/runner/.julia/registries
20K     /home/runner/.julia/scratchspaces
1.1G    total
Run if [ -d "~/.julia/registries" ] && [ -n "$(ls -A "~/.julia/registries")" ]; then
Registries directory does not exist or is empty. Skipping registry update
```

The problem turned out to be that using `~` in a quoted path doesn't expand it which results in failed checks:
```sh
❯ [ -d "~/.julia/registries" ] && [ -n "$(ls -A "~/.julia/registries")" ] && echo pass

❯ [ -d "$HOME/.julia/registries" ] && [ -n "$(ls -A "$HOME/.julia/registries")" ] && echo pass
pass
```
Seems best we just use the expanded path to avoid these kind of mistakes from occurring again.