### PR TITLE
fix windows depot path expansion

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -66,7 +66,11 @@ runs:
         else
             depot="~/.julia"
         fi
-        depot="${depot/#\~/$HOME}"  # Expand tilde which cannot be used in BASH checks (i.e. `[ -d "~/.julia" ]` fails)
+        if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]]; then
+          depot="${depot/#\~/$USERPROFILE}"  # Windows paths
+        else
+          depot="${depot/#\~/$HOME}"  # Unix-like paths
+        fi
         echo "depot=$depot" | tee -a "$GITHUB_OUTPUT"
 
         cache_paths=()


### PR DESCRIPTION
Fixes #145 
I guess the bug came from https://github.com/julia-actions/cache/pull/141 but I'm not sure the situation was better before that.

I'll test externally to check.