### PR TITLE
Avoid evaluation of command substitution in input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -58,8 +58,8 @@ runs:
 
     - id: paths
       run: |
-        if [ -n "${{ inputs.depot }}" ]; then
-            depot="${{ inputs.depot }}"
+        if [ -n '${{ inputs.depot }}' ]; then
+            depot='${{ inputs.depot }}'
         elif [ -n "$JULIA_DEPOT_PATH" ]; then
             # Use the first depot path
             depot=$(echo $JULIA_DEPOT_PATH | cut -d$PATH_DELIMITER -f1)
@@ -75,11 +75,11 @@ runs:
 
         cache_paths=()
         artifacts_path="${depot}/artifacts"
-        [ "${{ inputs.cache-artifacts }}" = "true" ] && cache_paths+=("$artifacts_path")
+        [ '${{ inputs.cache-artifacts }}' = "true" ] && cache_paths+=("$artifacts_path")
         packages_path="${depot}/packages"
-        [ "${{ inputs.cache-packages }}" = "true" ] && cache_paths+=("$packages_path")
+        [ '${{ inputs.cache-packages }}' = "true" ] && cache_paths+=("$packages_path")
         registries_path="${depot}/registries"
-        if [ "${{ inputs.cache-registries }}" = "true" ]; then
+        if [ '${{ inputs.cache-registries }}' = "true" ]; then
             if [ ! -d "${registries_path}" ]; then
                 cache_paths+=("$registries_path")
             else
@@ -87,11 +87,11 @@ runs:
             fi
         fi
         compiled_path="${depot}/compiled"
-        [ "${{ inputs.cache-compiled }}" = "true" ] && cache_paths+=("$compiled_path")
+        [ '${{ inputs.cache-compiled }}' = "true" ] && cache_paths+=("$compiled_path")
         scratchspaces_path="${depot}/scratchspaces"
-        [ "${{ inputs.cache-scratchspaces }}" = "true" ] && cache_paths+=("$scratchspaces_path")
+        [ '${{ inputs.cache-scratchspaces }}' = "true" ] && cache_paths+=("$scratchspaces_path")
         logs_path="${depot}/logs"
-        [ "${{ inputs.cache-logs }}" = "true" ] && cache_paths+=("$logs_path")
+        [ '${{ inputs.cache-logs }}' = "true" ] && cache_paths+=("$logs_path")
         {
             echo "cache-paths<<EOF"
             printf "%s\n" "${cache_paths[@]}"
@@ -106,10 +106,10 @@ runs:
       run: |
         # `matrix_key` joins all of matrix keys/values (including nested objects) to ensure that concurrent runs each use a unique cache key.
         # When `matrix` isn't set for the job then `MATRIX_JSON=null`.
-        if [ "${{ inputs.include-matrix }}" == "true" ] && [ "$MATRIX_JSON" != "null" ]; then
+        if [ '${{ inputs.include-matrix }}' == "true" ] && [ "$MATRIX_JSON" != "null" ]; then
           matrix_key=$(echo "$MATRIX_JSON" | jq 'paths(type != "object") as $p | ($p | join("-")) + "=" + (getpath($p) | tostring)' | jq -rs 'join(";") | . + ";"')
         fi
-        restore_key="${{ inputs.cache-name }};os=${{ runner.os }};${matrix_key}"
+        restore_key='${{ inputs.cache-name }};os=${{ runner.os }};${matrix_key}'
         # URL encode any restricted characters:
         # https://github.com/actions/toolkit/blob/5430c5d84832076372990c7c27f900878ff66dc9/packages/cache/src/cache.ts#L38-L43
         restore_key=$(sed 's/,/%2C/g' <<<"${restore_key}")
@@ -179,7 +179,7 @@ runs:
         # seems like there has to be a `main` step in this action. Could list caches for info if we wanted
         # main:  julia ${{ github.action_path }}/handle_caches.jl "${{ github.repository }}" "list"
         main: echo ""
-        post: julia $GITHUB_ACTION_PATH/handle_caches.jl rm "${{ github.repository }}" "${{ steps.keys.outputs.restore-key }}" "${{ github.ref }}" "${{ inputs.delete-old-caches != 'required' }}"
+        post: julia $GITHUB_ACTION_PATH/handle_caches.jl rm '${{ github.repository }}' '${{ steps.keys.outputs.restore-key }}' '${{ github.ref }}' "${{ inputs.delete-old-caches != 'required' }}"
       env:
         GH_TOKEN: ${{ inputs.token }}
 
@@ -190,7 +190,7 @@ runs:
               runner.OS == 'Windows' }}
       with:
         main: echo ""
-        post: cd %GITHUB_ACTION_PATH% && julia handle_caches.jl rm "${{ github.repository }}" "${{ steps.keys.outputs.restore-key }}" "${{ github.ref }}" "${{ inputs.delete-old-caches != 'required' }}"
+        post: cd %GITHUB_ACTION_PATH% && julia handle_caches.jl rm '${{ github.repository }}' '${{ steps.keys.outputs.restore-key }}' '${{ github.ref }}' "${{ inputs.delete-old-caches != 'required' }}"
       env:
         GH_TOKEN: ${{ inputs.token }}
 


### PR DESCRIPTION
In the body of the bash script, `${{ inputs }}` parameters are often quoted with double quotes, which allow command substitution.  This replaces double quotes with single quotes to prevent that and avoid command substitution.

First spotted in https://github.com/EnzymeAD/Reactant.jl/actions/runs/11603689684/job/32311135543#step:3:87. Note that the `restore_key` is set to
```
  restore_key="julia-cache;workflow=Format `main`;job=format;os=Linux;${matrix_key}"
```
Note the workflow is called literally `` Format `main` ``, which inside double quotes is evaluated, leading to an error in this case, but it opens the door to arbitrary code execution just by tweaking the workflow name.