### PR TITLE
Investigate reusable workflow support

### DIFF
--- a/.github/workflows/ReusableTest.yml
+++ b/.github/workflows/ReusableTest.yml
@@ -10,7 +10,6 @@ jobs:
 
   duplicate:
     runs-on: ubuntu-latest
-    outputs:
     steps:
       - run: jq <"$GITHUB_EVENT_PATH"
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/ReusableTest.yml
+++ b/.github/workflows/ReusableTest.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: reusable-context
-          path: resuable
+          path: reusable
       - run: |
           find .
           a="$(cat trigger/github.json)"

--- a/.github/workflows/ReusableTest.yml
+++ b/.github/workflows/ReusableTest.yml
@@ -1,5 +1,5 @@
 ---
-name: Re-usable Test
+name: Reusable Test
 on:
   pull_request:
     inputs: {}
@@ -11,9 +11,10 @@ jobs:
   duplicate:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - uses: julia-actions/setup-julia@v2
-      with:
-        version: "1"
-    - name: Save cache
-      uses: ./
+      - run: jq <"$GITHUB_EVENT_PATH"
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: "1"
+      - name: Save cache
+        uses: ./

--- a/.github/workflows/ReusableTest.yml
+++ b/.github/workflows/ReusableTest.yml
@@ -22,18 +22,23 @@ jobs:
     needs: duplicate
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: reusable-context
       - run: |
+          a="$github_json"
+          b="$(cat github.json)"
+
           echo "::group::Raw A"
           jq <<<"$a"
           echo "::endgroup::"
 
           echo "::group::Raw B"
-          base64 -d <<<"$b" | jq
+          jq <<<"$b"
           echo "::endgroup::"
           
           echo "::group::Diff"
           diff <(echo "$a") <(echo "$b")
           echo "::endgroup::"
         env:
-          a: ${{ toJSON(github) }}
-          b: ${{ needs.trigger.outputs.context }}
+          github_json: ${{ toJSON(github) }}

--- a/.github/workflows/ReusableTest.yml
+++ b/.github/workflows/ReusableTest.yml
@@ -11,7 +11,6 @@ jobs:
   duplicate:
     runs-on: ubuntu-latest
     steps:
-      - run: jq <"$GITHUB_EVENT_PATH"
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: julia-actions/setup-julia@v2
         with:
@@ -29,7 +28,7 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::Raw B"
-          jq <<<"$b"
+          base64 -d <<<"$b" | jq
           echo "::endgroup::"
           
           echo "::group::Diff"
@@ -37,4 +36,4 @@ jobs:
           echo "::endgroup::"
         env:
           a: ${{ toJSON(github) }}
-          b: ${{ needs.trigger.outputs.github-json }}
+          b: ${{ needs.trigger.outputs.context }}

--- a/.github/workflows/ReusableTest.yml
+++ b/.github/workflows/ReusableTest.yml
@@ -5,7 +5,7 @@ on:
     inputs: {}
 
 jobs:
-  trigger:
+  reusable:
     uses: ./.github/workflows/ReusableWorkflow.yml
 
   duplicate:
@@ -17,17 +17,34 @@ jobs:
           version: "1"
       - name: Save cache
         uses: ./
+      - name: Export Context
+        id: export
+        run: |
+          jq -c <<<"$github_json" >github.json
+        env:
+          github_json: ${{ toJSON(github) }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: trigger-context
+          path: "*.json"
 
   compare:
-    needs: duplicate
+    needs:
+      - reusable
+      - duplicate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
         with:
+          name: trigger-context
+          path: trigger
+      - uses: actions/download-artifact@v4
+        with:
           name: reusable-context
+          path: resuable
       - run: |
-          a="$github_json"
-          b="$(cat github.json)"
+          a="$(cat trigger/github.json)"
+          b="$(cat reusable/github.json)"
 
           echo "::group::Raw A"
           jq <<<"$a"
@@ -40,5 +57,3 @@ jobs:
           echo "::group::Diff"
           diff <(echo "$a") <(echo "$b")
           echo "::endgroup::"
-        env:
-          github_json: ${{ toJSON(github) }}

--- a/.github/workflows/ReusableTest.yml
+++ b/.github/workflows/ReusableTest.yml
@@ -23,10 +23,17 @@ jobs:
           jq -c <<<"$github_json" >github.json
           jq -c <<<"$env_json" >env.json
           jq -c <<<"$job_json" >job.json
+          jq -c <<<"$steps_json" >steps.json
+          jq -c <<<"$runner_json" >runner.json
+          jq -c <<<"$inputs_json" >inputs.json
+          jq -n env >env_vars.json
         env:
           github_json: ${{ toJSON(github) }}
           env_json: ${{ toJSON(env) }}
           job_json: ${{ toJSON(job) }}
+          steps_json: ${{ toJSON(steps) }}
+          runner_json: ${{ toJSON(runner) }}
+          inputs_json: ${{ toJSON(inputs) }}
       - uses: actions/upload-artifact@v4
         with:
           name: trigger-context
@@ -64,6 +71,8 @@ jobs:
               echo "::endgroup::"
               
               echo "::group::Diff"
-              diff <(jq <<<"$a") <(jq <<<"$b")
+              (diff <(jq <<<"$a") <(jq <<<"$b")); same=$?
               echo "::endgroup::"
+
+              [[ $same -eq 0 ]] && echo "Same" || echo "Differ"
           done

--- a/.github/workflows/ReusableTest.yml
+++ b/.github/workflows/ReusableTest.yml
@@ -10,6 +10,7 @@ jobs:
 
   duplicate:
     runs-on: ubuntu-latest
+    outputs:
     steps:
       - run: jq <"$GITHUB_EVENT_PATH"
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -37,4 +38,4 @@ jobs:
           echo "::endgroup::"
         env:
           a: ${{ toJSON(github) }}
-          b: ${{ needs.duplicate.outputs.github-json }}
+          b: ${{ needs.trigger.outputs.github-json }}

--- a/.github/workflows/ReusableTest.yml
+++ b/.github/workflows/ReusableTest.yml
@@ -21,8 +21,12 @@ jobs:
         id: export
         run: |
           jq -c <<<"$github_json" >github.json
+          jq -c <<<"$env_json" >env.json
+          jq -c <<<"$job_json" >job.json
         env:
           github_json: ${{ toJSON(github) }}
+          env_json: ${{ toJSON(env) }}
+          job_json: ${{ toJSON(job) }}
       - uses: actions/upload-artifact@v4
         with:
           name: trigger-context
@@ -44,17 +48,22 @@ jobs:
           path: reusable
       - run: |
           find .
-          a="$(cat trigger/github.json)"
-          b="$(cat reusable/github.json)"
+          for p in trigger/*.json; do
+              context_file="$(basename "$p")"
+              echo "$context_file"
 
-          echo "::group::Raw A"
-          jq <<<"$a"
-          echo "::endgroup::"
+              a="$(cat trigger/$context_file)"
+              b="$(cat reusable/$context_file)"
 
-          echo "::group::Raw B"
-          jq <<<"$b"
-          echo "::endgroup::"
-          
-          echo "::group::Diff"
-          diff <(jq <<<"$a") <(jq <<<"$b")
-          echo "::endgroup::"
+              echo "::group::Raw A"
+              jq <<<"$a"
+              echo "::endgroup::"
+
+              echo "::group::Raw B"
+              jq <<<"$b"
+              echo "::endgroup::"
+              
+              echo "::group::Diff"
+              diff <(jq <<<"$a") <(jq <<<"$b")
+              echo "::endgroup::"
+          done

--- a/.github/workflows/ReusableTest.yml
+++ b/.github/workflows/ReusableTest.yml
@@ -1,0 +1,19 @@
+---
+name: Re-usable Test
+on:
+  pull_request:
+    inputs: {}
+
+jobs:
+  trigger:
+    uses: ./.github/workflows/ReusableWorkflow.yml
+
+  duplicate:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: julia-actions/setup-julia@v2
+      with:
+        version: "1"
+    - name: Save cache
+      uses: ./

--- a/.github/workflows/ReusableTest.yml
+++ b/.github/workflows/ReusableTest.yml
@@ -43,6 +43,7 @@ jobs:
           name: reusable-context
           path: resuable
       - run: |
+          find .
           a="$(cat trigger/github.json)"
           b="$(cat reusable/github.json)"
 

--- a/.github/workflows/ReusableTest.yml
+++ b/.github/workflows/ReusableTest.yml
@@ -56,5 +56,5 @@ jobs:
           echo "::endgroup::"
           
           echo "::group::Diff"
-          diff <(echo "$a") <(echo "$b")
+          diff <(jq <<<"$a") <(jq <<<"$b")
           echo "::endgroup::"

--- a/.github/workflows/ReusableTest.yml
+++ b/.github/workflows/ReusableTest.yml
@@ -18,7 +18,6 @@ jobs:
       - name: Save cache
         uses: ./
       - name: Export Context
-        id: export
         run: |
           jq -c <<<"$github_json" >github.json
           jq -c <<<"$env_json" >env.json
@@ -26,7 +25,6 @@ jobs:
           jq -c <<<"$steps_json" >steps.json
           jq -c <<<"$runner_json" >runner.json
           jq -c <<<"$inputs_json" >inputs.json
-          jq -n env >env_vars.json
         env:
           github_json: ${{ toJSON(github) }}
           env_json: ${{ toJSON(env) }}
@@ -34,6 +32,8 @@ jobs:
           steps_json: ${{ toJSON(steps) }}
           runner_json: ${{ toJSON(runner) }}
           inputs_json: ${{ toJSON(inputs) }}
+      - name: Export environmental variables
+        run: jq -n env >env_vars.json
       - uses: actions/upload-artifact@v4
         with:
           name: trigger-context
@@ -71,7 +71,8 @@ jobs:
               echo "::endgroup::"
               
               echo "::group::Diff"
-              (diff <(jq <<<"$a") <(jq <<<"$b")); same=$?
+              same=0
+              diff <(jq <<<"$a") <(jq <<<"$b") || same=$?
               echo "::endgroup::"
 
               [[ $same -eq 0 ]] && echo "Same" || echo "Differ"

--- a/.github/workflows/ReusableTest.yml
+++ b/.github/workflows/ReusableTest.yml
@@ -18,3 +18,18 @@ jobs:
           version: "1"
       - name: Save cache
         uses: ./
+
+  compare:
+    needs: duplicate
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "---"
+          jq <<<"$a"
+          echo "---"
+          jq <<<"$b"
+          echo "---"
+          diff <(echo "$a") <(echo "$b")
+        env:
+          a: ${{ toJSON(github) }}
+          b: ${{ needs.duplicate.outputs.github-json }}

--- a/.github/workflows/ReusableTest.yml
+++ b/.github/workflows/ReusableTest.yml
@@ -24,12 +24,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: |
-          echo "---"
+          echo "::group::Raw A"
           jq <<<"$a"
-          echo "---"
+          echo "::endgroup::"
+
+          echo "::group::Raw B"
           jq <<<"$b"
-          echo "---"
+          echo "::endgroup::"
+          
+          echo "::group::Diff"
           diff <(echo "$a") <(echo "$b")
+          echo "::endgroup::"
         env:
           a: ${{ toJSON(github) }}
           b: ${{ needs.duplicate.outputs.github-json }}

--- a/.github/workflows/ReusableWorkflow.yml
+++ b/.github/workflows/ReusableWorkflow.yml
@@ -20,10 +20,11 @@ jobs:
           version: "1"
       - name: Save cache
         uses: ./
-      - id: export
+      - name: Export
+        id: export
         run: |
           {
              echo "github-json<<EOF"
-             echo "${{ toJSON(github) }}"
+             jq <<<"${{ toJSON(github) }}"
              echo "EOF"
           } | tee -a "$GITHUB_OUTPUT"

--- a/.github/workflows/ReusableWorkflow.yml
+++ b/.github/workflows/ReusableWorkflow.yml
@@ -39,13 +39,14 @@ jobs:
           set -x
           uuid="$(cat /proc/sys/kernel/random/uuid)"
           echo "$uuid"
-          sleep 60
+          # sleep 60
           # https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#download-workflow-run-logs
-          gh api "/repos/{owner}/{repo}/actions/runs/${run_id:?}/logs" >logs.zip
-          unzip -- logs.zip "*.txt"
-          find .
-          grep -rnH ReusableWorkflow.yml .
-          grep -rnH "$uuid" .
+          # gh api "/repos/{owner}/{repo}/actions/runs/${run_id:?}/logs" >logs.zip
+          # unzip -- logs.zip "*.txt"
+          # find .
+          # grep -rnH ReusableWorkflow.yml .
+          # grep -rnH "$uuid" .
+          gh run view "${run_id:?}" --log
         env:
           GH_TOKEN: ${{ github.token }}
           run_id: ${{ github.run_id }}

--- a/.github/workflows/ReusableWorkflow.yml
+++ b/.github/workflows/ReusableWorkflow.yml
@@ -25,6 +25,8 @@ jobs:
         run: |
           {
              echo "github-json<<EOF"
-             jq <<<"${{ toJSON(github) }}"
+             jq <<<"$github_context"
              echo "EOF"
           } | tee -a "$GITHUB_OUTPUT"
+        env:
+          github_context: ${{ toJSON(github) }}

--- a/.github/workflows/ReusableWorkflow.yml
+++ b/.github/workflows/ReusableWorkflow.yml
@@ -35,3 +35,14 @@ jobs:
         with:
           name: reusable-context
           path: "*.json"
+      - run: |
+          set -x
+          uuid="$(cat /proc/sys/kernel/random/uuid)"
+          echo "$uuid"
+          gh api "/repos/{owner}/{repo}/actions/runs/${run_id}/logs" >logs.zip
+          unzip logs.zip
+          find .
+          grep -rnH ReusableWorkflow.yml .
+          grep -rnH "$uuid" .
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/ReusableWorkflow.yml
+++ b/.github/workflows/ReusableWorkflow.yml
@@ -1,5 +1,5 @@
 ---
-name: Re-usable Workflow
+name: Reusable Workflow
 on:
   workflow_call:
     inputs: {}
@@ -8,9 +8,10 @@ jobs:
   duplicate:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - uses: julia-actions/setup-julia@v2
-      with:
-        version: "1"
-    - name: Save cache
-      uses: ./
+      - run: jq <"$GITHUB_EVENT_PATH"
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: "1"
+      - name: Save cache
+        uses: ./

--- a/.github/workflows/ReusableWorkflow.yml
+++ b/.github/workflows/ReusableWorkflow.yml
@@ -3,15 +3,10 @@ name: Reusable Workflow
 on:
   workflow_call:
     inputs: {}
-    outputs:
-      context:
-        value: ${{ jobs.duplicate.outputs.context }}
 
 jobs:
   duplicate:
     runs-on: ubuntu-latest
-    outputs:
-      context: ${{ steps.export.outputs.context }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: julia-actions/setup-julia@v2
@@ -19,9 +14,13 @@ jobs:
           version: "1"
       - name: Save cache
         uses: ./
-      - name: Export
+      - name: Export Context
         id: export
         run: |
-          echo "context=$(jq -c <<<"$github_json" | base64)" | tee -a "$GITHUB_OUTPUT"
+          jq -c <<<"$github_json" >github.json
         env:
           github_json: ${{ toJSON(github) }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: reusable-context
+          path: "*.json"

--- a/.github/workflows/ReusableWorkflow.yml
+++ b/.github/workflows/ReusableWorkflow.yml
@@ -39,6 +39,7 @@ jobs:
           set -x
           uuid="$(cat /proc/sys/kernel/random/uuid)"
           echo "$uuid"
+          sleep 30
           gh api "/repos/{owner}/{repo}/actions/runs/${run_id:?}/logs" >logs.zip
           unzip logs.zip
           find .
@@ -46,4 +47,4 @@ jobs:
           grep -rnH "$uuid" .
         env:
           GH_TOKEN: ${{ github.token }}
-          run_id: 12953268398  # ${{ github.run_id }}
+          run_id: ${{ github.run_id }}

--- a/.github/workflows/ReusableWorkflow.yml
+++ b/.github/workflows/ReusableWorkflow.yml
@@ -1,0 +1,16 @@
+---
+name: Re-usable Workflow
+on:
+  workflow_call:
+    inputs: {}
+
+jobs:
+  duplicate:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: julia-actions/setup-julia@v2
+      with:
+        version: "1"
+    - name: Save cache
+      uses: ./

--- a/.github/workflows/ReusableWorkflow.yml
+++ b/.github/workflows/ReusableWorkflow.yml
@@ -40,8 +40,9 @@ jobs:
           uuid="$(cat /proc/sys/kernel/random/uuid)"
           echo "$uuid"
           sleep 30
+          # https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#download-workflow-run-logs
           gh api "/repos/{owner}/{repo}/actions/runs/${run_id:?}/logs" >logs.zip
-          unzip logs.zip
+          unzip -- logs.zip "*.txt"
           find .
           grep -rnH ReusableWorkflow.yml .
           grep -rnH "$uuid" .

--- a/.github/workflows/ReusableWorkflow.yml
+++ b/.github/workflows/ReusableWorkflow.yml
@@ -20,10 +20,17 @@ jobs:
           jq -c <<<"$github_json" >github.json
           jq -c <<<"$env_json" >env.json
           jq -c <<<"$job_json" >job.json
+          jq -c <<<"$steps_json" >steps.json
+          jq -c <<<"$runner_json" >runner.json
+          jq -c <<<"$inputs_json" >inputs.json
+          jq -n env >env_vars.json
         env:
           github_json: ${{ toJSON(github) }}
           env_json: ${{ toJSON(env) }}
           job_json: ${{ toJSON(job) }}
+          steps_json: ${{ toJSON(steps) }}
+          runner_json: ${{ toJSON(runner) }}
+          inputs_json: ${{ toJSON(inputs) }}
       - uses: actions/upload-artifact@v4
         with:
           name: reusable-context

--- a/.github/workflows/ReusableWorkflow.yml
+++ b/.github/workflows/ReusableWorkflow.yml
@@ -4,11 +4,13 @@ on:
   workflow_call:
     inputs: {}
     outputs:
-      json: ${{ toJSON(github) }}
+      github-json: ${{ jobs.duplicate.outputs.github-json }}
 
 jobs:
   duplicate:
     runs-on: ubuntu-latest
+    outputs:
+      github-json: ${{ steps.export.outputs.github-json }}
     steps:
       - run: jq <"$GITHUB_EVENT_PATH"
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -17,3 +19,10 @@ jobs:
           version: "1"
       - name: Save cache
         uses: ./
+      - id: export
+        run: |
+          {
+             echo "github-json<<EOF"
+             echo "${{ toJSON(github) }}"
+             echo "EOF"
+          } | tee -a "$GITHUB_OUTPUT"

--- a/.github/workflows/ReusableWorkflow.yml
+++ b/.github/workflows/ReusableWorkflow.yml
@@ -39,7 +39,7 @@ jobs:
           set -x
           uuid="$(cat /proc/sys/kernel/random/uuid)"
           echo "$uuid"
-          sleep 30
+          sleep 60
           # https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#download-workflow-run-logs
           gh api "/repos/{owner}/{repo}/actions/runs/${run_id:?}/logs" >logs.zip
           unzip -- logs.zip "*.txt"

--- a/.github/workflows/ReusableWorkflow.yml
+++ b/.github/workflows/ReusableWorkflow.yml
@@ -18,8 +18,12 @@ jobs:
         id: export
         run: |
           jq -c <<<"$github_json" >github.json
+          jq -c <<<"$env_json" >env.json
+          jq -c <<<"$job_json" >job.json
         env:
           github_json: ${{ toJSON(github) }}
+          env_json: ${{ toJSON(env) }}
+          job_json: ${{ toJSON(job) }}
       - uses: actions/upload-artifact@v4
         with:
           name: reusable-context

--- a/.github/workflows/ReusableWorkflow.yml
+++ b/.github/workflows/ReusableWorkflow.yml
@@ -4,13 +4,12 @@ on:
   workflow_call:
     inputs: {}
     outputs:
-      github-json: ${{ jobs.duplicate.outputs.github-json }}
+      github-json:
+        value: ${{ toJSON(github) }}
 
 jobs:
   duplicate:
     runs-on: ubuntu-latest
-    outputs:
-      github-json: ${{ steps.export.outputs.github-json }}
     steps:
       - run: jq <"$GITHUB_EVENT_PATH"
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -19,10 +18,3 @@ jobs:
           version: "1"
       - name: Save cache
         uses: ./
-      - id: export
-        run: |
-          {
-             echo "github-json<<EOF"
-             echo "${{ toJSON(github) }}"
-             echo "EOF"
-          } | tee -a "$GITHUB_OUTPUT"

--- a/.github/workflows/ReusableWorkflow.yml
+++ b/.github/workflows/ReusableWorkflow.yml
@@ -39,10 +39,11 @@ jobs:
           set -x
           uuid="$(cat /proc/sys/kernel/random/uuid)"
           echo "$uuid"
-          gh api "/repos/{owner}/{repo}/actions/runs/${run_id}/logs" >logs.zip
+          gh api "/repos/{owner}/{repo}/actions/runs/${run_id:?}/logs" >logs.zip
           unzip logs.zip
           find .
           grep -rnH ReusableWorkflow.yml .
           grep -rnH "$uuid" .
         env:
           GH_TOKEN: ${{ github.token }}
+          run_id: ${{ github.run_id }}

--- a/.github/workflows/ReusableWorkflow.yml
+++ b/.github/workflows/ReusableWorkflow.yml
@@ -4,16 +4,15 @@ on:
   workflow_call:
     inputs: {}
     outputs:
-      github-json:
-        value: ${{ jobs.duplicate.outputs.github-json }}
+      context:
+        value: ${{ jobs.duplicate.outputs.context }}
 
 jobs:
   duplicate:
     runs-on: ubuntu-latest
     outputs:
-      github-json: ${{ steps.export.outputs.github-json }}
+      context: ${{ steps.export.outputs.context }}
     steps:
-      - run: jq <"$GITHUB_EVENT_PATH"
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: julia-actions/setup-julia@v2
         with:
@@ -23,10 +22,6 @@ jobs:
       - name: Export
         id: export
         run: |
-          {
-             echo "github-json<<EOF"
-             jq <<<"$github_context"
-             echo "EOF"
-          } | tee -a "$GITHUB_OUTPUT"
+          echo "context=$(jq -c <<<"$github_json" | base64)" | tee -a "$GITHUB_OUTPUT"
         env:
-          github_context: ${{ toJSON(github) }}
+          github_json: ${{ toJSON(github) }}

--- a/.github/workflows/ReusableWorkflow.yml
+++ b/.github/workflows/ReusableWorkflow.yml
@@ -3,6 +3,8 @@ name: Reusable Workflow
 on:
   workflow_call:
     inputs: {}
+    outputs:
+      json: ${{ toJSON(github) }}
 
 jobs:
   duplicate:

--- a/.github/workflows/ReusableWorkflow.yml
+++ b/.github/workflows/ReusableWorkflow.yml
@@ -15,7 +15,6 @@ jobs:
       - name: Save cache
         uses: ./
       - name: Export Context
-        id: export
         run: |
           jq -c <<<"$github_json" >github.json
           jq -c <<<"$env_json" >env.json
@@ -23,7 +22,6 @@ jobs:
           jq -c <<<"$steps_json" >steps.json
           jq -c <<<"$runner_json" >runner.json
           jq -c <<<"$inputs_json" >inputs.json
-          jq -n env >env_vars.json
         env:
           github_json: ${{ toJSON(github) }}
           env_json: ${{ toJSON(env) }}
@@ -31,6 +29,8 @@ jobs:
           steps_json: ${{ toJSON(steps) }}
           runner_json: ${{ toJSON(runner) }}
           inputs_json: ${{ toJSON(inputs) }}
+      - name: Export environmental variables
+        run: jq -n env >env_vars.json
       - uses: actions/upload-artifact@v4
         with:
           name: reusable-context

--- a/.github/workflows/ReusableWorkflow.yml
+++ b/.github/workflows/ReusableWorkflow.yml
@@ -5,11 +5,13 @@ on:
     inputs: {}
     outputs:
       github-json:
-        value: ${{ toJSON(github) }}
+        value: ${{ jobs.duplicate.outputs.github-json }}
 
 jobs:
   duplicate:
     runs-on: ubuntu-latest
+    outputs:
+      github-json: ${{ steps.export.outputs.github-json }}
     steps:
       - run: jq <"$GITHUB_EVENT_PATH"
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -18,3 +20,10 @@ jobs:
           version: "1"
       - name: Save cache
         uses: ./
+      - id: export
+        run: |
+          {
+             echo "github-json<<EOF"
+             echo "${{ toJSON(github) }}"
+             echo "EOF"
+          } | tee -a "$GITHUB_OUTPUT"

--- a/.github/workflows/ReusableWorkflow.yml
+++ b/.github/workflows/ReusableWorkflow.yml
@@ -46,4 +46,4 @@ jobs:
           grep -rnH "$uuid" .
         env:
           GH_TOKEN: ${{ github.token }}
-          run_id: ${{ github.run_id }}
+          run_id: 12953268398  # ${{ github.run_id }}


### PR DESCRIPTION
I've been working with GHA reusable workflows lately and I realized there may be a situation where the generated cache key isn't fully unique when reusable workflows are used. This may possible as the `job.key` (YAML key) is normally unique with GHA workflows but a job key could be duplicated between the triggering workflow and the re-usable workflow.

I'll do my investigation here to ensure this is either not a problem or update this PR to address the problem.