### PR TITLE
Output `cache-paths` and `cache-key` as well

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,12 @@ outputs:
   cache-hit:
     description: A boolean value to indicate an exact match was found for the primary key. Returns "" when the key is new. Forwarded from actions/cache.
     value: ${{ steps.hit.outputs.cache-hit }}
+  cache-paths:
+    description: The paths that were cached
+    value: ${{ steps.paths.outputs.cache-paths }}
+  cache-key:
+    description: The full cache key used
+    value: ${{ steps.keys.outputs.key }}
 
 runs:
   using: 'composite'


### PR DESCRIPTION
Hello! I've been looking for a way to save the cache even if an intermediate step fails (https://github.com/julia-actions/cache/issues/79). (Context: on Turing.jl docs it takes 10 mins to instantiate the environment and 2 hours to build the docs, so having this would save a lot of time on PRs)

I understand that a 'nicer' solution to this would depend on upstream fixes to GitHub Actions, but this PR seems like a good enough way to do it. The gist is that as long as we know the cache paths and the key, we can manually call `actions/cache/save` to save the cache at the bottom of the workflow. (That's also the workflow that [GitHub said to use](https://github.com/actions/cache/issues/1315#issuecomment-2163822166).)

So if `julia-actions/cache` outputs this as variables, it becomes easy to write something like

```yaml
jobs:
  test:
    runs-on: ubuntu-latest

    steps:
      - uses: actions/checkout@v4

      - name: Load Julia packages from cache
        id: julia-cache
        uses: julia-actions/cache@v2
        with:
          cache-name: foo

      # do whatever you want here (that might fail)

      - name: Save Julia depot cache
        id: julia-cache-save
        if: always() && steps.julia-cache.outputs.cache-hit != 'true'
        uses: actions/cache/save@v4
        with: 
          path: |
            ${{ steps.julia-cache.outputs.cache-paths }}
          key: ${{ steps.julia-cache.outputs.cache-key }}
```

I've tested this with my fork and it works perfectly. You can see the first time the action runs here (no cache hit, and an intermediate step fails, but the cache is still saved):

https://github.com/penelopeysm/Shaymin.jl/actions/runs/14022967403/job/39257320572

and a subsequent run where the cache is then correctly loaded:

https://github.com/penelopeysm/Shaymin.jl/actions/runs/14022985223/job/39257363646