### PR TITLE
Delete pidfiles. Skip Pkg.gc when not saving. Don't delete old caches if no new saved. 

### DIFF
--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -87235,6 +87235,16 @@ async function run() {
         if (cacheScratchspaces) cachePaths.push(scratchspacesPath);
         if (cacheLogs) cachePaths.push(logsPath);
 
+        // Exclude stale pidfiles – they are auto-cleaned but should not be cached.
+        // Each pattern targets only the specific depth where Julia/Pkg places them.
+        // Both .pid and .pidfile extensions are matched for forward-compatibility.
+        cachePaths.push(`!${depotPath}/artifacts/*.{pid,pidfile}`);           // Pkg artifact locks
+        cachePaths.push(`!${depotPath}/compiled/v*.*/*.{pid,pidfile}`);       // Julia base precompile locks (UUID-less packages)
+        cachePaths.push(`!${depotPath}/compiled/v*.*/*/*.{pid,pidfile}`);     // Julia base precompile locks (registry packages)
+        cachePaths.push(`!${depotPath}/packages/*/*.{pid,pidfile}`);          // Pkg package source locks
+        cachePaths.push(`!${depotPath}/registries/*/.{pid,pidfile}`);         // Pkg registry locks
+        cachePaths.push(`!${depotPath}/logs/*.{pid,pidfile}`);                // Pkg usage file locks
+
         core.setOutput('cache-paths', cachePaths.join('\n'));
 
         // Generate cache keys

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -87212,12 +87212,14 @@ async function run() {
             return;
         }
 
+        let cacheSaved = false;
         if (cachePaths.length > 0) {
             // Save the cache
             core.info(`Saving cache with key: ${cacheKey}`);
             try {
                 await cache.saveCache(cachePaths, cacheKey);
                 core.info('Cache saved successfully');
+                cacheSaved = true;
             } catch (error) {
                 if (error.name === 'ReserveCacheError') {
                     core.info('Cache already exists, skipping save.');
@@ -87225,6 +87227,11 @@ async function run() {
                     core.warning(`Failed to save cache: ${error.message}`);
                 }
             }
+        }
+
+        if (!cacheSaved) {
+            core.info('No new cache was saved. Skipping old cache deletion.');
+            return;
         }
 
         // Check if on default branch

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -87209,7 +87209,10 @@ async function run() {
         // Don't save if we got an exact cache hit (cache is already up to date)
         if (cacheMatchedKey === cacheKey) {
             core.info('Cache hit occurred on the exact key, not saving cache.');
-        } else if (cachePaths.length > 0) {
+            return;
+        }
+
+        if (cachePaths.length > 0) {
             // Save the cache
             core.info(`Saving cache with key: ${cacheKey}`);
             try {

--- a/src/main.js
+++ b/src/main.js
@@ -66,6 +66,16 @@ async function run() {
         if (cacheScratchspaces) cachePaths.push(scratchspacesPath);
         if (cacheLogs) cachePaths.push(logsPath);
 
+        // Exclude stale pidfiles – they are auto-cleaned but should not be cached.
+        // Each pattern targets only the specific depth where Julia/Pkg places them.
+        // Both .pid and .pidfile extensions are matched for forward-compatibility.
+        cachePaths.push(`!${depotPath}/artifacts/*.{pid,pidfile}`);           // Pkg artifact locks
+        cachePaths.push(`!${depotPath}/compiled/v*.*/*.{pid,pidfile}`);       // Julia base precompile locks (UUID-less packages)
+        cachePaths.push(`!${depotPath}/compiled/v*.*/*/*.{pid,pidfile}`);     // Julia base precompile locks (registry packages)
+        cachePaths.push(`!${depotPath}/packages/*/*.{pid,pidfile}`);          // Pkg package source locks
+        cachePaths.push(`!${depotPath}/registries/*/.{pid,pidfile}`);         // Pkg registry locks
+        cachePaths.push(`!${depotPath}/logs/*.{pid,pidfile}`);                // Pkg usage file locks
+
         core.setOutput('cache-paths', cachePaths.join('\n'));
 
         // Generate cache keys

--- a/src/post.js
+++ b/src/post.js
@@ -43,12 +43,14 @@ async function run() {
             return;
         }
 
+        let cacheSaved = false;
         if (cachePaths.length > 0) {
             // Save the cache
             core.info(`Saving cache with key: ${cacheKey}`);
             try {
                 await cache.saveCache(cachePaths, cacheKey);
                 core.info('Cache saved successfully');
+                cacheSaved = true;
             } catch (error) {
                 if (error.name === 'ReserveCacheError') {
                     core.info('Cache already exists, skipping save.');
@@ -56,6 +58,11 @@ async function run() {
                     core.warning(`Failed to save cache: ${error.message}`);
                 }
             }
+        }
+
+        if (!cacheSaved) {
+            core.info('No new cache was saved. Skipping old cache deletion.');
+            return;
         }
 
         // Check if on default branch

--- a/src/post.js
+++ b/src/post.js
@@ -40,7 +40,10 @@ async function run() {
         // Don't save if we got an exact cache hit (cache is already up to date)
         if (cacheMatchedKey === cacheKey) {
             core.info('Cache hit occurred on the exact key, not saving cache.');
-        } else if (cachePaths.length > 0) {
+            return;
+        }
+
+        if (cachePaths.length > 0) {
             // Save the cache
             core.info(`Saving cache with key: ${cacheKey}`);
             try {


### PR DESCRIPTION
This PR addresses three related issues in the post action:

- **Exclude pidfiles from cache** (#179): Adds targeted glob exclusions so stale pidfiles created by Julia and Pkg are never stored in or restored from the cache. Patterns are scoped to the exact depot subdirectories where Julia/Pkg place them (`artifacts/`, `compiled/v*.*/`, `packages/`, `registries/`, `logs/`), avoiding accidental exclusion of `.pid`/`.pidfile` files that may be legitimate content inside artifacts or packages.

- **Skip Pkg.gc on exact cache hit** (#175): When the restore key matches the save key exactly, the cache is already up to date and nothing new will be saved. The post action now returns early in this case, avoiding a needless `Pkg.gc()` run.

- **Don't delete old caches if no new cache was saved** (#168): Old-cache deletion now only runs when `saveCache` actually succeeded. If saving fails or is skipped for any reason, the post action returns early so existing caches are left intact.

Fixes #179
Fixes #175
Fixes #168

🤖 Generated by GitHub Copilot (Claude Sonnet 4.6).