### PR TITLE
`AGENTS.md`: Add rules about putting changes to generated files (`dist/*` and `package-lock.json`) in separate commits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,8 @@ These instructions apply to work performed by LLM coding agents in this reposito
 ## Git Commits
 
 - Add yourself as a co-author on every commit you make.
+- Changes that modify `dist/*` should go into a separate commit.
+- Changes that modify `package-lock.json` should go into a separate commit.
 
 ## Pull Requests
 


### PR DESCRIPTION
This PR adds the following rules to `AGENTS.md`:
1. Require `dist/*` changes to be committed separately.
2. Require `package-lock.json` changes to be committed separately.

I like these rules for a couple reasons:
1. It makes review easier.
3. It makes it easier when rebasing and fixing merge conflicts. Because, worst case, you just drop those commits entirely, and then recreate the changes by doing `npm install` or `make everything-from-scratch`.

🤖 Generated by OpenAI Codex.