### PR TITLE
Dependabot: Set a 7-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    # Cooldown applies only to version updates, not security updates.
+    # https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 99
     labels:
       - "dependencies"
@@ -13,6 +17,10 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    # Cooldown applies only to version updates, not security updates.
+    # https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 99
     labels:
       - "dependencies"


### PR DESCRIPTION
This PR sets a 7-day cooldown for both (`github-actions` and `npm`) of the package ecosystems in our Dependabot config.

Per the [GitHub docs](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-):

> The `cooldown` option is only available for _version_ updates, not _security_ updates.

🤖 Generated by OpenAI Codex.
