### PR TITLE
Add optional prefix for uploads

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,9 @@ inputs:
   gcp-compression:
     description: Compression algorithm to use for GCP storage caching ('zstd' or 'gzip').
     default: 'zstd'
+  key-prefix:
+    description: Optional prefix to prepend to the cache key (and GCS object path, if using GCP).
+    default: ''
   depot:
     description: Path to a Julia depot directory where cached data will be saved to and restored from.
     default: ''

--- a/src/main.js
+++ b/src/main.js
@@ -86,6 +86,7 @@ async function run() {
         const saveAlways = core.getInput('save-always') === 'true';
         const gcpBucket = core.getInput('gcp-bucket');
         const gcpCompression = parseGcpCompressionInput(core.getInput('gcp-compression'));
+        const keyPrefix = core.getInput('key-prefix');
 
         if (gcpBucket && gcpCompression === 'zstd' && !isZstdAvailable()) {
             throw new Error("zstd is not available on this runner. Please install zstd or set `gcp-compression: 'gzip'` to use gzip compression.");
@@ -187,7 +188,7 @@ async function run() {
             }
         }
 
-        let restoreKey = `${cacheName};os=${runnerOS};${matrixKey}`;
+        let restoreKey = `${keyPrefix}${cacheName};os=${runnerOS};${matrixKey}`;
         // URL encode restricted characters
         restoreKey = restoreKey.replace(/,/g, '%2C');
 


### PR DESCRIPTION
Adding a prefix is especially relevant for gcp-style uploads, in particular unlike github where all caches are separated per repo, a single bucket may be used for multiple repos, requiring a prefix to avoid accidentally having two different repos sharing the same bucket from sharing the same cache files