### PR TITLE
`.gitattributes`: Hide generated JS code from diffs and language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Hide generated JS code from diffs and language stats
+dist/** linguist-generated=true


### PR DESCRIPTION
Co-authored-by: Sascha Mann @SaschaMann 